### PR TITLE
Fixed outdated Script Canvas node references

### DIFF
--- a/scriptcanvas/Car.scriptcanvas
+++ b/scriptcanvas/Car.scriptcanvas
@@ -5,7 +5,7 @@
     "ClassData": {
         "m_scriptCanvas": {
             "Id": {
-                "id": 150988932067154
+                "id": 48961601916672
             },
             "Name": "Script Canvas Graph",
             "Components": {
@@ -20,6 +20,7 @@
                                 },
                                 "Value": {
                                     "Datum": {
+                                        "isOverloadedStorage": false,
                                         "scriptCanvasType": {
                                             "m_type": 3
                                         },
@@ -39,6 +40,7 @@
                                 },
                                 "Value": {
                                     "Datum": {
+                                        "isOverloadedStorage": false,
                                         "scriptCanvasType": {
                                             "m_type": 3
                                         },
@@ -58,6 +60,7 @@
                                 },
                                 "Value": {
                                     "Datum": {
+                                        "isOverloadedStorage": false,
                                         "scriptCanvasType": {
                                             "m_type": 8
                                         },
@@ -85,7 +88,7 @@
                         "m_nodes": [
                             {
                                 "Id": {
-                                    "id": 151066241478482
+                                    "id": 49043206295296
                                 },
                                 "Name": "SC-Node(HeartBeatNodeableNode)",
                                 "Components": {
@@ -212,6 +215,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -279,7 +283,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151070536445778
+                                    "id": 49030321393408
                                 },
                                 "Name": "SC Node(GetVariable)",
                                 "Components": {
@@ -350,7 +354,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151053356576594
+                                    "id": 49017436491520
                                 },
                                 "Name": "EBusEventHandler",
                                 "Components": {
@@ -528,6 +532,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -590,7 +595,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151040471674706
+                                    "id": 49004551589632
                                 },
                                 "Name": "SC-Node(ScriptCanvas_StringFunctions_EndsWith)",
                                 "Components": {
@@ -717,6 +722,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -726,6 +732,7 @@
                                                 "label": "Source"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -735,6 +742,7 @@
                                                 "label": "Pattern"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -766,7 +774,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151027586772818
+                                    "id": 48991666687744
                                 },
                                 "Name": "SC-Node(SetLocalTranslation)",
                                 "Components": {
@@ -839,6 +847,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -850,6 +859,7 @@
                                                 "label": "Source"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 8
                                                 },
@@ -883,7 +893,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151018996838226
+                                    "id": 48978781785856
                                 },
                                 "Name": "SC-Node(ScriptCanvas_TransformFunctions_GetForward)",
                                 "Components": {
@@ -975,6 +985,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 7
                                                 },
@@ -997,6 +1008,7 @@
                                                 "label": "Source"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -1025,7 +1037,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151006111936338
+                                    "id": 48965896883968
                                 },
                                 "Name": "SC-Node(Start)",
                                 "Components": {
@@ -1055,7 +1067,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151057651543890
+                                    "id": 49047501262592
                                 },
                                 "Name": "SendScriptEvent",
                                 "Components": {
@@ -1104,6 +1116,7 @@
                                             "assetId": {
                                                 "guid": "{192B5ACD-AA8B-5097-A03F-8F25DC7733CE}"
                                             },
+                                            "loadBehavior": "PreLoad",
                                             "assetHint": "scriptcanvas/paper_kid_script_events.scriptevents"
                                         },
                                         "m_busId": {
@@ -1117,7 +1130,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 150993227034450
+                                    "id": 49034616360704
                                 },
                                 "Name": "SC-EventNode(On Collision Begin event)",
                                 "Components": {
@@ -1140,7 +1153,7 @@
                                                     {
                                                         "$type": "RestrictedNodeContract",
                                                         "m_nodeId": {
-                                                            "id": 151044766642002
+                                                            "id": 49008846556928
                                                         }
                                                     }
                                                 ],
@@ -1271,7 +1284,7 @@
                                                     {
                                                         "$type": "RestrictedNodeContract",
                                                         "m_nodeId": {
-                                                            "id": 151044766642002
+                                                            "id": 49008846556928
                                                         }
                                                     }
                                                 ],
@@ -1314,7 +1327,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151074831413074
+                                    "id": 49021731458816
                                 },
                                 "Name": "SC-Node(OperatorAdd)",
                                 "Components": {
@@ -1532,6 +1545,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 8
                                                 },
@@ -1545,6 +1559,7 @@
                                                 "label": "Vector3 0"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 8
                                                 },
@@ -1563,7 +1578,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151044766642002
+                                    "id": 49008846556928
                                 },
                                 "Name": "SC-Node(GetOnCollisionBeginEvent)",
                                 "Components": {
@@ -1640,6 +1655,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -1648,7 +1664,7 @@
                                                 "value": {
                                                     "id": 2901262558
                                                 },
-                                                "label": "EntityId"
+                                                "label": "Entity Id"
                                             }
                                         ],
                                         "methodType": 2,
@@ -1668,7 +1684,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151010406903634
+                                    "id": 48995961655040
                                 },
                                 "Name": "SC-Node(SetLocalRotation)",
                                 "Components": {
@@ -1741,6 +1757,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -1752,6 +1769,7 @@
                                                 "label": "Source"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 8
                                                 },
@@ -1785,7 +1803,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151049061609298
+                                    "id": 48983076753152
                                 },
                                 "Name": "SC-Node(GetEntityName)",
                                 "Components": {
@@ -1861,6 +1879,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -1889,7 +1908,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151031881740114
+                                    "id": 48970191851264
                                 },
                                 "Name": "SC-Node(GetLocalTranslation)",
                                 "Components": {
@@ -1965,6 +1984,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -1993,7 +2013,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151023291805522
+                                    "id": 49051796229888
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -2128,6 +2148,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 8
                                                 },
@@ -2184,7 +2205,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151014701870930
+                                    "id": 49038911328000
                                 },
                                 "Name": "SC-Node(GetWorldTM)",
                                 "Components": {
@@ -2260,6 +2281,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -2288,7 +2310,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151061946511186
+                                    "id": 49026026426112
                                 },
                                 "Name": "SC-Node(OperatorDiv)",
                                 "Components": {
@@ -2437,6 +2459,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -2446,6 +2469,7 @@
                                                 "label": "Number 0"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -2460,109 +2484,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 150997522001746
-                                },
-                                "Name": "SC-Node(Get Body 2 EntityId)",
-                                "Components": {
-                                    "Component_[5676325724704497894]": {
-                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
-                                        "Id": 5676325724704497894,
-                                        "Slots": [
-                                            {
-                                                "id": {
-                                                    "m_id": "{D23C4158-1D54-4589-8FEA-34B837C05456}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "CollisionEvent",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{79022470-BF91-4975-9F19-43BA5D4AC1DC}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "In",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{4C2712C1-39E6-4A67-9001-B0DCB0F3DDFF}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Out",
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{E15E9F28-E394-4DFF-94AA-B10FCE19851C}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "EntityId",
-                                                "DisplayDataType": {
-                                                    "m_type": 1
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            }
-                                        ],
-                                        "Datums": [
-                                            {
-                                                "scriptCanvasType": {
-                                                    "m_type": 4,
-                                                    "m_azType": "{7602AA36-792C-4BDC-BDF8-AA16792151A3}"
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "CollisionEvent",
-                                                "label": "CollisionEvent"
-                                            }
-                                        ],
-                                        "methodType": 2,
-                                        "methodName": "Get Body 2 EntityId",
-                                        "className": "CollisionEvent",
-                                        "resultSlotIDs": [
-                                            {}
-                                        ],
-                                        "inputSlots": [
-                                            {
-                                                "m_id": "{D23C4158-1D54-4589-8FEA-34B837C05456}"
-                                            }
-                                        ],
-                                        "prettyClassName": "CollisionEvent"
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 151079126380370
+                                    "id": 49000256622336
                                 },
                                 "Name": "SC Node(GetVariable)",
                                 "Components": {
@@ -2633,7 +2555,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151036176707410
+                                    "id": 48987371720448
                                 },
                                 "Name": "SC-Node(ScriptCanvas_Vector3Functions_MultiplyByNumber)",
                                 "Components": {
@@ -2729,6 +2651,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 8
                                                 },
@@ -2742,6 +2665,7 @@
                                                 "label": "Source"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -2770,7 +2694,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151001816969042
+                                    "id": 48974486818560
                                 },
                                 "Name": "SC-Node(OperatorMul)",
                                 "Components": {
@@ -2955,6 +2879,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -2964,6 +2889,7 @@
                                                 "label": "Number 0"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -2975,12 +2901,111 @@
                                         ]
                                     }
                                 }
+                            },
+                            {
+                                "Id": {
+                                    "id": 361429062635264
+                                },
+                                "Name": "SC-Node(GetBody2EntityId)",
+                                "Components": {
+                                    "Component_[9695116539058011494]": {
+                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
+                                        "Id": 9695116539058011494,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{DCF2592B-3FA6-4D72-A60B-312940CF55E6}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "CollisionEvent",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{5FD02948-AEA8-4D85-9E35-6CBD5FF0DF6A}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{4E0C4A8D-0572-4159-80DA-4999A5B9A896}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A2B87EC2-3E12-4AB4-88C7-E5621F3D36A9}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{7602AA36-792C-4BDC-BDF8-AA16792151A3}"
+                                                },
+                                                "isNullPointer": true,
+                                                "label": "Collision Event"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "GetBody2EntityId",
+                                        "className": "CollisionEvent",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{DCF2592B-3FA6-4D72-A60B-312940CF55E6}"
+                                            }
+                                        ],
+                                        "prettyClassName": "CollisionEvent"
+                                    }
+                                }
                             }
                         ],
                         "m_connections": [
                             {
                                 "Id": {
-                                    "id": 151083421347666
+                                    "id": 49056091197184
                                 },
                                 "Name": "srcEndpoint=(HeartBeat: Pulse), destEndpoint=(GetLocalTranslation: In)",
                                 "Components": {
@@ -2989,7 +3014,7 @@
                                         "Id": 4440104547878818575,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151066241478482
+                                                "id": 49043206295296
                                             },
                                             "slotId": {
                                                 "m_id": "{A3FB3DEE-1E9B-4853-8F63-9F9DDD55086D}"
@@ -2997,7 +3022,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151031881740114
+                                                "id": 48970191851264
                                             },
                                             "slotId": {
                                                 "m_id": "{707EF6A9-0329-4048-AF2D-31566DB843BB}"
@@ -3008,7 +3033,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151087716314962
+                                    "id": 49060386164480
                                 },
                                 "Name": "srcEndpoint=(Add (+): Out), destEndpoint=(SetLocalTranslation: In)",
                                 "Components": {
@@ -3017,7 +3042,7 @@
                                         "Id": 7282591168518162215,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151074831413074
+                                                "id": 49021731458816
                                             },
                                             "slotId": {
                                                 "m_id": "{5F9C8EF1-89ED-4876-BAAA-1EBC5AD30A49}"
@@ -3025,7 +3050,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151027586772818
+                                                "id": 48991666687744
                                             },
                                             "slotId": {
                                                 "m_id": "{E19B4EBF-40F4-4DA3-83B0-DEAEB6958628}"
@@ -3036,7 +3061,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151092011282258
+                                    "id": 49064681131776
                                 },
                                 "Name": "srcEndpoint=(Add (+): Result), destEndpoint=(SetLocalTranslation: Vector3: 1)",
                                 "Components": {
@@ -3045,7 +3070,7 @@
                                         "Id": 8053735492915386319,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151074831413074
+                                                "id": 49021731458816
                                             },
                                             "slotId": {
                                                 "m_id": "{7472B661-BEB3-4221-B1F6-C0F4C90B0069}"
@@ -3053,7 +3078,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151027586772818
+                                                "id": 48991666687744
                                             },
                                             "slotId": {
                                                 "m_id": "{B35B920C-E898-42C1-B303-733CCC413721}"
@@ -3064,7 +3089,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151096306249554
+                                    "id": 49068976099072
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Divide (/): In)",
                                 "Components": {
@@ -3073,7 +3098,7 @@
                                         "Id": 15683615988767835899,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151079126380370
+                                                "id": 49000256622336
                                             },
                                             "slotId": {
                                                 "m_id": "{3C85BDA8-2DD6-4A37-9759-F302E83D7D2D}"
@@ -3081,7 +3106,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151061946511186
+                                                "id": 49026026426112
                                             },
                                             "slotId": {
                                                 "m_id": "{63E4A931-2FAA-4328-AC8D-B096FB2AF5C6}"
@@ -3092,7 +3117,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151100601216850
+                                    "id": 49073271066368
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(Divide (/): Value 0)",
                                 "Components": {
@@ -3101,7 +3126,7 @@
                                         "Id": 5568933993160353782,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151079126380370
+                                                "id": 49000256622336
                                             },
                                             "slotId": {
                                                 "m_id": "{6BD0C2FC-B35E-4C52-9964-1D5AD4ED5906}"
@@ -3109,7 +3134,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151061946511186
+                                                "id": 49026026426112
                                             },
                                             "slotId": {
                                                 "m_id": "{542BE869-5ACE-4C95-A1AA-A438319D371B}"
@@ -3120,7 +3145,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151104896184146
+                                    "id": 49077566033664
                                 },
                                 "Name": "srcEndpoint=(Divide (/): Out), destEndpoint=(Get Variable: In)",
                                 "Components": {
@@ -3129,7 +3154,7 @@
                                         "Id": 10323803147320302031,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151061946511186
+                                                "id": 49026026426112
                                             },
                                             "slotId": {
                                                 "m_id": "{158E8A83-3F51-4C74-B915-EE49CB260E10}"
@@ -3137,7 +3162,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151070536445778
+                                                "id": 49030321393408
                                             },
                                             "slotId": {
                                                 "m_id": "{AAA43CB5-6BDB-4060-9C66-CAB86C0AD626}"
@@ -3148,7 +3173,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151109191151442
+                                    "id": 49081861000960
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Multiply (*): In)",
                                 "Components": {
@@ -3157,7 +3182,7 @@
                                         "Id": 14126112590447976897,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151070536445778
+                                                "id": 49030321393408
                                             },
                                             "slotId": {
                                                 "m_id": "{02901D74-B379-4479-8F4B-ED2D06095604}"
@@ -3165,7 +3190,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151001816969042
+                                                "id": 48974486818560
                                             },
                                             "slotId": {
                                                 "m_id": "{CA807B09-DAF2-4A2C-A19C-7E4236CE49F0}"
@@ -3176,7 +3201,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151113486118738
+                                    "id": 49086155968256
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(Multiply (*): Value 0)",
                                 "Components": {
@@ -3185,7 +3210,7 @@
                                         "Id": 13407302703500034473,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151070536445778
+                                                "id": 49030321393408
                                             },
                                             "slotId": {
                                                 "m_id": "{9C871B27-32B9-42EF-984F-1EF2978DD543}"
@@ -3193,7 +3218,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151001816969042
+                                                "id": 48974486818560
                                             },
                                             "slotId": {
                                                 "m_id": "{96A37EE5-2575-4C03-9F1E-0CB38DC02606}"
@@ -3204,7 +3229,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151117781086034
+                                    "id": 49090450935552
                                 },
                                 "Name": "srcEndpoint=(Divide (/): Result), destEndpoint=(Multiply (*): Number 1)",
                                 "Components": {
@@ -3213,7 +3238,7 @@
                                         "Id": 5562664367512058335,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151061946511186
+                                                "id": 49026026426112
                                             },
                                             "slotId": {
                                                 "m_id": "{12053C76-EAF4-449F-8D88-7ED8376F96C2}"
@@ -3221,7 +3246,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151001816969042
+                                                "id": 48974486818560
                                             },
                                             "slotId": {
                                                 "m_id": "{C62E28E3-9579-4AAB-A8AB-502B3F4CA3BA}"
@@ -3232,7 +3257,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151122076053330
+                                    "id": 49094745902848
                                 },
                                 "Name": "srcEndpoint=(GetLocalTranslation: Out), destEndpoint=(Get Variable: In)",
                                 "Components": {
@@ -3241,7 +3266,7 @@
                                         "Id": 14025719657911946920,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151031881740114
+                                                "id": 48970191851264
                                             },
                                             "slotId": {
                                                 "m_id": "{D8506844-9348-49D0-AA6E-0C3221669DAF}"
@@ -3249,7 +3274,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151079126380370
+                                                "id": 49000256622336
                                             },
                                             "slotId": {
                                                 "m_id": "{86FE540C-1064-4610-B669-C50A32EE29E7}"
@@ -3260,7 +3285,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151126371020626
+                                    "id": 49099040870144
                                 },
                                 "Name": "srcEndpoint=(GetLocalTranslation: Vector3), destEndpoint=(Add (+): Vector3 0)",
                                 "Components": {
@@ -3269,7 +3294,7 @@
                                         "Id": 13127358680389582375,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151031881740114
+                                                "id": 48970191851264
                                             },
                                             "slotId": {
                                                 "m_id": "{D72501D4-89EA-43B4-B86F-A7D3FA2351DB}"
@@ -3277,7 +3302,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151074831413074
+                                                "id": 49021731458816
                                             },
                                             "slotId": {
                                                 "m_id": "{46346F7B-474A-4D8C-8C6B-CF6866182002}"
@@ -3288,7 +3313,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151130665987922
+                                    "id": 49103335837440
                                 },
                                 "Name": "srcEndpoint=(GetOnCollisionBeginEvent: Event<AZStd::tuple<Crc32, int>, const CollisionEvent&>), destEndpoint=(On Collision Begin event: On Collision Begin event)",
                                 "Components": {
@@ -3297,7 +3322,7 @@
                                         "Id": 3502965575876239345,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151044766642002
+                                                "id": 49008846556928
                                             },
                                             "slotId": {
                                                 "m_id": "{01AA0426-3AC1-430E-87F4-CD871CEF555E}"
@@ -3305,7 +3330,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 150993227034450
+                                                "id": 49034616360704
                                             },
                                             "slotId": {
                                                 "m_id": "{B30B1B74-33AD-4925-8E5D-7E4231B19E66}"
@@ -3316,7 +3341,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151134960955218
+                                    "id": 49107630804736
                                 },
                                 "Name": "srcEndpoint=(GetOnCollisionBeginEvent: Out), destEndpoint=(On Collision Begin event: Connect)",
                                 "Components": {
@@ -3325,7 +3350,7 @@
                                         "Id": 18135208721232891869,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151044766642002
+                                                "id": 49008846556928
                                             },
                                             "slotId": {
                                                 "m_id": "{30F51AD2-9303-44D3-89FB-18577FEDF981}"
@@ -3333,7 +3358,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 150993227034450
+                                                "id": 49034616360704
                                             },
                                             "slotId": {
                                                 "m_id": "{B7333B41-D19B-4DD8-ACC8-8B3B6B215825}"
@@ -3344,7 +3369,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151139255922514
+                                    "id": 49111925772032
                                 },
                                 "Name": "srcEndpoint=(EntityBus Handler: ExecutionSlot:OnEntityActivated), destEndpoint=(GetOnCollisionBeginEvent: In)",
                                 "Components": {
@@ -3353,7 +3378,7 @@
                                         "Id": 12050872996067158090,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151053356576594
+                                                "id": 49017436491520
                                             },
                                             "slotId": {
                                                 "m_id": "{727ABBA7-D63A-457C-B63C-30CA6C81A8A9}"
@@ -3361,7 +3386,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151044766642002
+                                                "id": 49008846556928
                                             },
                                             "slotId": {
                                                 "m_id": "{D68CC0C1-845B-4650-921B-659399E1FC11}"
@@ -3372,7 +3397,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151143550889810
+                                    "id": 49116220739328
                                 },
                                 "Name": "srcEndpoint=(GetEntityName: Out), destEndpoint=(ScriptCanvas_StringFunctions_EndsWith: In)",
                                 "Components": {
@@ -3381,7 +3406,7 @@
                                         "Id": 6868136763471421230,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151049061609298
+                                                "id": 48983076753152
                                             },
                                             "slotId": {
                                                 "m_id": "{947729F7-7752-4F73-A584-255BA3FC231C}"
@@ -3389,7 +3414,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151040471674706
+                                                "id": 49004551589632
                                             },
                                             "slotId": {
                                                 "m_id": "{3E2CDE5F-CCA7-4A78-BA3B-9DFE13093918}"
@@ -3400,7 +3425,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151147845857106
+                                    "id": 49120515706624
                                 },
                                 "Name": "srcEndpoint=(GetEntityName: String), destEndpoint=(ScriptCanvas_StringFunctions_EndsWith: Source)",
                                 "Components": {
@@ -3409,7 +3434,7 @@
                                         "Id": 11956301527588291387,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151049061609298
+                                                "id": 48983076753152
                                             },
                                             "slotId": {
                                                 "m_id": "{27150FF5-8B09-4E0F-B37A-2B85CF39C004}"
@@ -3417,7 +3442,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151040471674706
+                                                "id": 49004551589632
                                             },
                                             "slotId": {
                                                 "m_id": "{5FBBA5E0-F942-4A75-A08F-69434A9E0F99}"
@@ -3428,119 +3453,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151152140824402
-                                },
-                                "Name": "srcEndpoint=(On Collision Begin event: OnEvent), destEndpoint=(Get Body 2 EntityId: In)",
-                                "Components": {
-                                    "Component_[2428986100493413727]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 2428986100493413727,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 150993227034450
-                                            },
-                                            "slotId": {
-                                                "m_id": "{8CE6885A-C46C-4FBF-A249-79D2041CCE4F}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 150997522001746
-                                            },
-                                            "slotId": {
-                                                "m_id": "{79022470-BF91-4975-9F19-43BA5D4AC1DC}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 151156435791698
-                                },
-                                "Name": "srcEndpoint=(On Collision Begin event: Collision Event), destEndpoint=(Get Body 2 EntityId: CollisionEvent)",
-                                "Components": {
-                                    "Component_[16405469083048000970]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 16405469083048000970,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 150993227034450
-                                            },
-                                            "slotId": {
-                                                "m_id": "{B32AB29E-D38E-43CF-B062-FC998F926C9A}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 150997522001746
-                                            },
-                                            "slotId": {
-                                                "m_id": "{D23C4158-1D54-4589-8FEA-34B837C05456}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 151160730758994
-                                },
-                                "Name": "srcEndpoint=(Get Body 2 EntityId: Out), destEndpoint=(GetEntityName: In)",
-                                "Components": {
-                                    "Component_[5412670741727245206]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 5412670741727245206,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 150997522001746
-                                            },
-                                            "slotId": {
-                                                "m_id": "{4C2712C1-39E6-4A67-9001-B0DCB0F3DDFF}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 151049061609298
-                                            },
-                                            "slotId": {
-                                                "m_id": "{986A3CC3-3C87-41F7-A00C-55587DABB350}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 151165025726290
-                                },
-                                "Name": "srcEndpoint=(Get Body 2 EntityId: EntityId), destEndpoint=(GetEntityName: EntityId)",
-                                "Components": {
-                                    "Component_[17833198124785486546]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 17833198124785486546,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 150997522001746
-                                            },
-                                            "slotId": {
-                                                "m_id": "{E15E9F28-E394-4DFF-94AA-B10FCE19851C}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 151049061609298
-                                            },
-                                            "slotId": {
-                                                "m_id": "{1127602F-F67C-4C0E-9988-C349650276A3}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 151169320693586
+                                    "id": 49141990543104
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_StringFunctions_EndsWith: True), destEndpoint=(Send Script Event: In)",
                                 "Components": {
@@ -3549,7 +3462,7 @@
                                         "Id": 16262565240280464320,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151040471674706
+                                                "id": 49004551589632
                                             },
                                             "slotId": {
                                                 "m_id": "{B541231A-30E5-4397-A831-5525AF80C682}"
@@ -3557,7 +3470,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151057651543890
+                                                "id": 49047501262592
                                             },
                                             "slotId": {
                                                 "m_id": "{0CD56A55-F88C-4AE8-829A-7AEF90A7DA34}"
@@ -3568,7 +3481,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151173615660882
+                                    "id": 49146285510400
                                 },
                                 "Name": "srcEndpoint=(On Graph Start: Out), destEndpoint=(GetWorldTM: In)",
                                 "Components": {
@@ -3577,7 +3490,7 @@
                                         "Id": 12521198788295398288,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151006111936338
+                                                "id": 48965896883968
                                             },
                                             "slotId": {
                                                 "m_id": "{4E4CDC48-1925-493A-B473-E7848784F5A0}"
@@ -3585,7 +3498,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151014701870930
+                                                "id": 49038911328000
                                             },
                                             "slotId": {
                                                 "m_id": "{FFF95C83-0C94-43CA-80EC-E89A04D8194C}"
@@ -3596,7 +3509,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151177910628178
+                                    "id": 49150580477696
                                 },
                                 "Name": "srcEndpoint=(GetWorldTM: Out), destEndpoint=(ScriptCanvas_TransformFunctions_GetForward: In)",
                                 "Components": {
@@ -3605,7 +3518,7 @@
                                         "Id": 15362499678320861716,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151014701870930
+                                                "id": 49038911328000
                                             },
                                             "slotId": {
                                                 "m_id": "{54C214EF-67FA-44B5-B629-D23FD4C9BB8E}"
@@ -3613,7 +3526,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151018996838226
+                                                "id": 48978781785856
                                             },
                                             "slotId": {
                                                 "m_id": "{FC6F04CF-3C3C-4BFF-96E6-FA7604749ADE}"
@@ -3624,7 +3537,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151182205595474
+                                    "id": 49154875444992
                                 },
                                 "Name": "srcEndpoint=(GetWorldTM: Transform), destEndpoint=(ScriptCanvas_TransformFunctions_GetForward: Source)",
                                 "Components": {
@@ -3633,7 +3546,7 @@
                                         "Id": 4778170839479021704,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151014701870930
+                                                "id": 49038911328000
                                             },
                                             "slotId": {
                                                 "m_id": "{AC0A1A8E-98CF-4FE7-A3C9-067EE59282C6}"
@@ -3641,7 +3554,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151018996838226
+                                                "id": 48978781785856
                                             },
                                             "slotId": {
                                                 "m_id": "{30EEB6ED-E778-4E1F-A722-50B2AAF5AAC6}"
@@ -3652,7 +3565,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151186500562770
+                                    "id": 49159170412288
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_TransformFunctions_GetForward: Out), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -3661,7 +3574,7 @@
                                         "Id": 6424197541573099907,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151018996838226
+                                                "id": 48978781785856
                                             },
                                             "slotId": {
                                                 "m_id": "{5C220946-5D2D-418C-A3BF-181B1EC1E3A1}"
@@ -3669,7 +3582,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151023291805522
+                                                "id": 49051796229888
                                             },
                                             "slotId": {
                                                 "m_id": "{3FAEABFC-CE3E-423A-8651-216FB09BC58B}"
@@ -3680,7 +3593,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151190795530066
+                                    "id": 49163465379584
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_TransformFunctions_GetForward: Vector3), destEndpoint=(Set Variable: Vector3)",
                                 "Components": {
@@ -3689,7 +3602,7 @@
                                         "Id": 17785213288848468699,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151018996838226
+                                                "id": 48978781785856
                                             },
                                             "slotId": {
                                                 "m_id": "{DB829753-C336-449F-B35E-1F5603CB7424}"
@@ -3697,7 +3610,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151023291805522
+                                                "id": 49051796229888
                                             },
                                             "slotId": {
                                                 "m_id": "{AFF845FB-4E13-455B-A24F-83B00FF49BC2}"
@@ -3708,7 +3621,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151195090497362
+                                    "id": 49167760346880
                                 },
                                 "Name": "srcEndpoint=(Set Variable: Out), destEndpoint=(HeartBeat: Start)",
                                 "Components": {
@@ -3717,7 +3630,7 @@
                                         "Id": 4749718635184535931,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151023291805522
+                                                "id": 49051796229888
                                             },
                                             "slotId": {
                                                 "m_id": "{028139FB-BE5B-45D5-A6E3-A705ED2B9B67}"
@@ -3725,7 +3638,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151066241478482
+                                                "id": 49043206295296
                                             },
                                             "slotId": {
                                                 "m_id": "{0B942881-716B-4264-94BA-C16D082D7527}"
@@ -3736,7 +3649,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151199385464658
+                                    "id": 49172055314176
                                 },
                                 "Name": "srcEndpoint=(Multiply (*): Out), destEndpoint=(ScriptCanvas_Vector3Functions_MultiplyByNumber: In)",
                                 "Components": {
@@ -3745,7 +3658,7 @@
                                         "Id": 6788609702298675553,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151001816969042
+                                                "id": 48974486818560
                                             },
                                             "slotId": {
                                                 "m_id": "{702A895D-550C-4863-B9F0-FF64F0327509}"
@@ -3753,7 +3666,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151036176707410
+                                                "id": 48987371720448
                                             },
                                             "slotId": {
                                                 "m_id": "{E8E3A834-727C-4586-9E73-F49E795FEBEF}"
@@ -3764,7 +3677,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151203680431954
+                                    "id": 49176350281472
                                 },
                                 "Name": "srcEndpoint=(Multiply (*): Result), destEndpoint=(ScriptCanvas_Vector3Functions_MultiplyByNumber: Multiplier)",
                                 "Components": {
@@ -3773,7 +3686,7 @@
                                         "Id": 13521374596650588598,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151001816969042
+                                                "id": 48974486818560
                                             },
                                             "slotId": {
                                                 "m_id": "{189EE647-3E23-407F-8461-DFE30DAA3FB7}"
@@ -3781,7 +3694,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151036176707410
+                                                "id": 48987371720448
                                             },
                                             "slotId": {
                                                 "m_id": "{DBED5A45-BF73-4C02-A199-A3C9D061F00A}"
@@ -3792,7 +3705,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151207975399250
+                                    "id": 49180645248768
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_Vector3Functions_MultiplyByNumber: Out), destEndpoint=(Add (+): In)",
                                 "Components": {
@@ -3801,7 +3714,7 @@
                                         "Id": 16808903695311900664,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151036176707410
+                                                "id": 48987371720448
                                             },
                                             "slotId": {
                                                 "m_id": "{C04F73E4-5FDE-4AAF-9E72-A452A2FFBEE8}"
@@ -3809,7 +3722,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151074831413074
+                                                "id": 49021731458816
                                             },
                                             "slotId": {
                                                 "m_id": "{E17A3DFB-F2AA-49B6-BAEF-908CD54ADF52}"
@@ -3820,7 +3733,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151212270366546
+                                    "id": 49184940216064
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_Vector3Functions_MultiplyByNumber: Vector3), destEndpoint=(Add (+): Vector3 1)",
                                 "Components": {
@@ -3829,7 +3742,7 @@
                                         "Id": 3909590152922003930,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151036176707410
+                                                "id": 48987371720448
                                             },
                                             "slotId": {
                                                 "m_id": "{80B49136-E915-4C38-8150-9828A63BDEB1}"
@@ -3837,7 +3750,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151074831413074
+                                                "id": 49021731458816
                                             },
                                             "slotId": {
                                                 "m_id": "{BFC75D39-F920-4A41-84FB-28E584FE96D7}"
@@ -3848,7 +3761,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 151216565333842
+                                    "id": 49189235183360
                                 },
                                 "Name": "srcEndpoint=(On Graph Start: Out), destEndpoint=(SetLocalRotation: In)",
                                 "Components": {
@@ -3857,7 +3770,7 @@
                                         "Id": 9171941380347648526,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 151006111936338
+                                                "id": 48965896883968
                                             },
                                             "slotId": {
                                                 "m_id": "{4E4CDC48-1925-493A-B473-E7848784F5A0}"
@@ -3865,10 +3778,122 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 151010406903634
+                                                "id": 48995961655040
                                             },
                                             "slotId": {
                                                 "m_id": "{24B1BE8C-096F-4919-894C-2A50E19187BA}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 362288056094464
+                                },
+                                "Name": "srcEndpoint=(On Collision Begin event: OnEvent), destEndpoint=(GetBody2EntityId: In)",
+                                "Components": {
+                                    "Component_[6972865483993645862]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 6972865483993645862,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 49034616360704
+                                            },
+                                            "slotId": {
+                                                "m_id": "{8CE6885A-C46C-4FBF-A249-79D2041CCE4F}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 361429062635264
+                                            },
+                                            "slotId": {
+                                                "m_id": "{5FD02948-AEA8-4D85-9E35-6CBD5FF0DF6A}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 362580113870592
+                                },
+                                "Name": "srcEndpoint=(On Collision Begin event: Collision Event), destEndpoint=(GetBody2EntityId: CollisionEvent)",
+                                "Components": {
+                                    "Component_[15114620155751835590]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 15114620155751835590,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 49034616360704
+                                            },
+                                            "slotId": {
+                                                "m_id": "{B32AB29E-D38E-43CF-B062-FC998F926C9A}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 361429062635264
+                                            },
+                                            "slotId": {
+                                                "m_id": "{DCF2592B-3FA6-4D72-A60B-312940CF55E6}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 362889351515904
+                                },
+                                "Name": "srcEndpoint=(GetBody2EntityId: Out), destEndpoint=(GetEntityName: In)",
+                                "Components": {
+                                    "Component_[395349082734841756]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 395349082734841756,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 361429062635264
+                                            },
+                                            "slotId": {
+                                                "m_id": "{4E0C4A8D-0572-4159-80DA-4999A5B9A896}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 48983076753152
+                                            },
+                                            "slotId": {
+                                                "m_id": "{986A3CC3-3C87-41F7-A00C-55587DABB350}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 363138459619072
+                                },
+                                "Name": "srcEndpoint=(GetBody2EntityId: EntityId), destEndpoint=(GetEntityName: EntityId)",
+                                "Components": {
+                                    "Component_[3472248562488114541]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 3472248562488114541,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 361429062635264
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A2B87EC2-3E12-4AB4-88C7-E5621F3D36A9}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 48983076753152
+                                            },
+                                            "slotId": {
+                                                "m_id": "{1127602F-F67C-4C0E-9988-C349650276A3}"
                                             }
                                         }
                                     }
@@ -3878,31 +3903,31 @@
                         "m_scriptEventAssets": [
                             [
                                 {
-                                    "id": 151057651543890
+                                    "id": 49047501262592
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 151057651543890
+                                    "id": 49047501262592
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 151057651543890
+                                    "id": 49047501262592
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 151057651543890
+                                    "id": 49047501262592
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 151057651543890
+                                    "id": 49047501262592
                                 },
                                 {}
                             ]
@@ -3918,7 +3943,7 @@
                     "GraphCanvasData": [
                         {
                             "Key": {
-                                "id": 150988932067154
+                                "id": 48961601916672
                             },
                             "Value": {
                                 "ComponentData": {
@@ -3947,7 +3972,7 @@
                                                         "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
                                                             "$type": "NodeGroupFrameComponentSaveData",
                                                             "DisplayHeight": 267.0,
-                                                            "DisplayWidth": 460.0,
+                                                            "DisplayWidth": 600.0,
                                                             "PersistentGroupedId": [
                                                                 "{D3C48CAC-3B21-481A-9425-1454DE109221}"
                                                             ]
@@ -3971,9 +3996,9 @@
                                             }
                                         ],
                                         "ViewParams": {
-                                            "Scale": 0.9538736627658744,
-                                            "AnchorX": -1087.1461181640625,
-                                            "AnchorY": 302.9751281738281
+                                            "Scale": 0.9024744241397901,
+                                            "AnchorX": 1334.10986328125,
+                                            "AnchorY": 868.72265625
                                         }
                                     }
                                 }
@@ -3981,99 +4006,7 @@
                         },
                         {
                             "Key": {
-                                "id": 150993227034450
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "HandlerNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1440.0,
-                                            1000.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".azeventhandler"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{3DCC4839-D6FE-4B41-AD22-D86008C03795}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 150997522001746
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1920.0,
-                                            1000.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{5703CC55-AD7C-4147-B856-3D91C5F8508B}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 151001816969042
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2500.0,
-                                            300.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{2CCDBAAB-55A2-4DDB-85B8-F79BC3B72E39}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 151006111936338
+                                "id": 48965896883968
                             },
                             "Value": {
                                 "ComponentData": {
@@ -4103,162 +4036,7 @@
                         },
                         {
                             "Key": {
-                                "id": 151010406903634
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            -620.0,
-                                            680.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{D3C48CAC-3B21-481A-9425-1454DE109221}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 151014701870930
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            -640.0,
-                                            320.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{E0E2B7B9-7D98-47FA-9FB3-C617ACCB9AAF}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 151018996838226
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            -180.0,
-                                            320.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{97369420-C340-4239-BA5B-531109B25F89}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 151023291805522
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "SetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            160.0,
-                                            300.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".setVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{7B141FFE-7AA5-47ED-AF08-0D610536F10C}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 151027586772818
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3680.0,
-                                            440.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F029E139-1922-4E2A-BCC9-D23602181D3F}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 151031881740114
+                                "id": 48970191851264
                             },
                             "Value": {
                                 "ComponentData": {
@@ -4289,7 +4067,7 @@
                         },
                         {
                             "Key": {
-                                "id": 151036176707410
+                                "id": 48974486818560
                             },
                             "Value": {
                                 "ComponentData": {
@@ -4298,29 +4076,28 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                        "PaletteOverride": "MathNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            2820.0,
+                                            2500.0,
                                             300.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
+                                        "$type": "StylingComponentSaveData"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F912086A-E123-46F0-B6B3-38DBA6702283}"
+                                        "PersistentId": "{2CCDBAAB-55A2-4DDB-85B8-F79BC3B72E39}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 151040471674706
+                                "id": 48978781785856
                             },
                             "Value": {
                                 "ComponentData": {
@@ -4334,8 +4111,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            2740.0,
-                                            1000.0
+                                            -180.0,
+                                            320.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -4344,45 +4121,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{00B77E2A-E8CB-4C0F-9CEB-47FA42318220}"
+                                        "PersistentId": "{97369420-C340-4239-BA5B-531109B25F89}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 151044766642002
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            840.0,
-                                            1020.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{FF78EA4C-D604-4C96-B2AC-F3231962EEC0}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 151049061609298
+                                "id": 48983076753152
                             },
                             "Value": {
                                 "ComponentData": {
@@ -4413,7 +4159,193 @@
                         },
                         {
                             "Key": {
-                                "id": 151053356576594
+                                "id": 48987371720448
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2820.0,
+                                            300.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{F912086A-E123-46F0-B6B3-38DBA6702283}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 48991666687744
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            3680.0,
+                                            440.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{F029E139-1922-4E2A-BCC9-D23602181D3F}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 48995961655040
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -620.0,
+                                            680.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{D3C48CAC-3B21-481A-9425-1454DE109221}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 49000256622336
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1400.0,
+                                            300.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{1BFF0BC9-3854-46CF-8801-27516D713C63}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 49004551589632
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2740.0,
+                                            1000.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{00B77E2A-E8CB-4C0F-9CEB-47FA42318220}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 49008846556928
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            840.0,
+                                            1020.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{FF78EA4C-D604-4C96-B2AC-F3231962EEC0}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 49017436491520
                             },
                             "Value": {
                                 "ComponentData": {
@@ -4447,7 +4379,7 @@
                         },
                         {
                             "Key": {
-                                "id": 151057651543890
+                                "id": 49021731458816
                             },
                             "Value": {
                                 "ComponentData": {
@@ -4456,29 +4388,28 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                        "PaletteOverride": "MathNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            3100.0,
-                                            1080.0
+                                            3320.0,
+                                            400.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
+                                        "$type": "StylingComponentSaveData"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{1C6EC183-319B-48C4-92AF-FD6BE640C740}"
+                                        "PersistentId": "{E85922F3-67E3-401D-9A03-C6C9D0897C3B}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 151061946511186
+                                "id": 49026026426112
                             },
                             "Value": {
                                 "ComponentData": {
@@ -4508,37 +4439,7 @@
                         },
                         {
                             "Key": {
-                                "id": 151066241478482
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "TimeNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            480.0,
-                                            300.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{3C8294A3-71FA-4545-8FE6-BB81FF48B500}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 151070536445778
+                                "id": 49030321393408
                             },
                             "Value": {
                                 "ComponentData": {
@@ -4569,7 +4470,7 @@
                         },
                         {
                             "Key": {
-                                "id": 151074831413074
+                                "id": 49034616360704
                             },
                             "Value": {
                                 "ComponentData": {
@@ -4578,13 +4479,75 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
+                                        "PaletteOverride": "HandlerNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            3320.0,
-                                            400.0
+                                            1440.0,
+                                            1000.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".azeventhandler"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{3DCC4839-D6FE-4B41-AD22-D86008C03795}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 49038911328000
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -640.0,
+                                            320.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{E0E2B7B9-7D98-47FA-9FB3-C617ACCB9AAF}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 49043206295296
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "TimeNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            480.0,
+                                            300.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -4592,14 +4555,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{E85922F3-67E3-401D-9A03-C6C9D0897C3B}"
+                                        "PersistentId": "{3C8294A3-71FA-4545-8FE6-BB81FF48B500}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 151079126380370
+                                "id": 49047501262592
                             },
                             "Value": {
                                 "ComponentData": {
@@ -4608,22 +4571,84 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                        "PaletteOverride": "MethodNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1400.0,
+                                            3100.0,
+                                            1080.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{1C6EC183-319B-48C4-92AF-FD6BE640C740}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 49051796229888
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            160.0,
                                             300.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
                                         "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".getVariable"
+                                        "SubStyle": ".setVariable"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{1BFF0BC9-3854-46CF-8801-27516D713C63}"
+                                        "PersistentId": "{7B141FFE-7AA5-47ED-AF08-0D610536F10C}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 361429062635264
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1920.0,
+                                            1040.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{BCCB0DEF-5266-46AE-9934-1048E636CCE7}"
                                     }
                                 }
                             }
@@ -4633,10 +4658,6 @@
                         "InstanceCounter": [
                             {
                                 "Key": 191865528901450421,
-                                "Value": 1
-                            },
-                            {
-                                "Key": 471087297389143161,
                                 "Value": 1
                             },
                             {
@@ -4673,6 +4694,10 @@
                             },
                             {
                                 "Key": 9017495172405820461,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 10103778464964995608,
                                 "Value": 1
                             },
                             {

--- a/scriptcanvas/NewspaperTarget.scriptcanvas
+++ b/scriptcanvas/NewspaperTarget.scriptcanvas
@@ -5,7 +5,7 @@
     "ClassData": {
         "m_scriptCanvas": {
             "Id": {
-                "id": 13467753380684
+                "id": 222804698189568
             },
             "Name": "Script Canvas Graph",
             "Components": {
@@ -16,123 +16,7 @@
                         "m_nodes": [
                             {
                                 "Id": {
-                                    "id": 461531626601292
-                                },
-                                "Name": "SC-Node(SetVisibility)",
-                                "Components": {
-                                    "Component_[10038356210066714976]": {
-                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
-                                        "Id": 10038356210066714976,
-                                        "Slots": [
-                                            {
-                                                "id": {
-                                                    "m_id": "{C79F1945-9ED8-44AA-9799-5FB1580811F4}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "EntityId: 0",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1,
-                                                "IsReference": true,
-                                                "VariableReference": {
-                                                    "m_id": "{AA7BD1D3-F303-4296-8544-231678555D16}"
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{50651DE6-3702-4423-8585-C657E4CB91FA}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Boolean: 1",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{E8A41188-3559-4EF3-9AA5-BC15D4EFEC03}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "In",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{76F4EC21-F5D2-4E2C-9155-2DB4BABA55B3}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Out",
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 1
-                                                }
-                                            }
-                                        ],
-                                        "Datums": [
-                                            {
-                                                "isOverloadedStorage": false,
-                                                "scriptCanvasType": {
-                                                    "m_type": 1
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "EntityId",
-                                                "value": {
-                                                    "id": 2901262558
-                                                },
-                                                "label": "Source"
-                                            },
-                                            {
-                                                "isOverloadedStorage": false,
-                                                "scriptCanvasType": {
-                                                    "m_type": 0
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "bool",
-                                                "value": true,
-                                                "label": "Boolean: 1"
-                                            }
-                                        ],
-                                        "methodType": 0,
-                                        "methodName": "SetVisibility",
-                                        "className": "RenderMeshComponentRequestBus",
-                                        "inputSlots": [
-                                            {
-                                                "m_id": "{C79F1945-9ED8-44AA-9799-5FB1580811F4}"
-                                            },
-                                            {
-                                                "m_id": "{50651DE6-3702-4423-8585-C657E4CB91FA}"
-                                            }
-                                        ],
-                                        "prettyClassName": "RenderMeshComponentRequestBus"
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 479622028852044
+                                    "id": 222920662306560
                                 },
                                 "Name": "SC-Node(SetVisibility)",
                                 "Components": {
@@ -251,7 +135,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 469945467534156
+                                    "id": 222955022044928
                                 },
                                 "Name": "SC-Node(SetVisibility)",
                                 "Components": {
@@ -370,7 +254,126 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13596602399564
+                                    "id": 222989381783296
+                                },
+                                "Name": "SC-Node(SetVisibility)",
+                                "Components": {
+                                    "Component_[10038356210066714976]": {
+                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
+                                        "Id": 10038356210066714976,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{C79F1945-9ED8-44AA-9799-5FB1580811F4}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId: 0",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "IsReference": true,
+                                                "VariableReference": {
+                                                    "m_id": "{AA7BD1D3-F303-4296-8544-231678555D16}"
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{50651DE6-3702-4423-8585-C657E4CB91FA}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Boolean: 1",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{E8A41188-3559-4EF3-9AA5-BC15D4EFEC03}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{76F4EC21-F5D2-4E2C-9155-2DB4BABA55B3}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 1
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "EntityId",
+                                                "value": {
+                                                    "id": 2901262558
+                                                },
+                                                "label": "Source"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 0
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "bool",
+                                                "value": true,
+                                                "label": "Boolean: 1"
+                                            }
+                                        ],
+                                        "methodType": 0,
+                                        "methodName": "SetVisibility",
+                                        "className": "RenderMeshComponentRequestBus",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{C79F1945-9ED8-44AA-9799-5FB1580811F4}"
+                                            },
+                                            {
+                                                "m_id": "{50651DE6-3702-4423-8585-C657E4CB91FA}"
+                                            }
+                                        ],
+                                        "prettyClassName": "RenderMeshComponentRequestBus"
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 222899187470080
                                 },
                                 "Name": "ReceiveScriptEvent",
                                 "Components": {
@@ -659,6 +662,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -668,6 +672,7 @@
                                                 "label": "String"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -855,6 +860,7 @@
                                             "assetId": {
                                                 "guid": "{192B5ACD-AA8B-5097-A03F-8F25DC7733CE}"
                                             },
+                                            "loadBehavior": "PreLoad",
                                             "assetHint": "scriptcanvas/paper_kid_script_events.scriptevents"
                                         },
                                         "m_autoConnectToGraphOwner": false
@@ -863,7 +869,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13579422530380
+                                    "id": 222937842175744
                                 },
                                 "Name": "SC-Node(GetEntityName)",
                                 "Components": {
@@ -939,6 +945,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -967,7 +974,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 402381337000780
+                                    "id": 222972201914112
                                 },
                                 "Name": "SC-Node(SetVisibility)",
                                 "Components": {
@@ -1069,6 +1076,9 @@
                                         "methodType": 0,
                                         "methodName": "SetVisibility",
                                         "className": "RenderMeshComponentRequestBus",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
                                         "inputSlots": [
                                             {
                                                 "m_id": "{F8C01B2A-4E29-4FFF-BD95-84BA179C261D}"
@@ -1083,7 +1093,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 403957589998412
+                                    "id": 222817583091456
                                 },
                                 "Name": "SC-Node(SetVisibility)",
                                 "Components": {
@@ -1202,7 +1212,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 369696635878220
+                                    "id": 222843352895232
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -1306,7 +1316,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13545062792012
+                                    "id": 222869122699008
                                 },
                                 "Name": "SC-Node(ScriptCanvas_StringFunctions_Split)",
                                 "Components": {
@@ -1401,6 +1411,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -1410,6 +1421,7 @@
                                                 "label": "Source"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -1438,7 +1450,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 414682123336524
+                                    "id": 222890597535488
                                 },
                                 "Name": "SC-Node(ScriptCanvas_EntityFunctions_IsValid)",
                                 "Components": {
@@ -1519,6 +1531,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -1546,7 +1559,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13549357759308
+                                    "id": 222997971717888
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -1624,6 +1637,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -1649,7 +1663,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13626667170636
+                                    "id": 222929252241152
                                 },
                                 "Name": "SC-Node(ScriptCanvas_StringFunctions_EndsWith)",
                                 "Components": {
@@ -1776,6 +1790,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -1785,6 +1800,7 @@
                                                 "label": "Source"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -1794,6 +1810,7 @@
                                                 "label": "Pattern"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -1825,7 +1842,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13510703053644
+                                    "id": 222963611979520
                                 },
                                 "Name": "SC-Node(ScriptCanvas_MathFunctions_StringToNumber)",
                                 "Components": {
@@ -1901,6 +1918,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -1926,7 +1944,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13570832595788
+                                    "id": 222808993156864
                                 },
                                 "Name": "SendScriptEvent",
                                 "Components": {
@@ -1985,6 +2003,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -2007,6 +2026,7 @@
                                             "assetId": {
                                                 "guid": "{192B5ACD-AA8B-5097-A03F-8F25DC7733CE}"
                                             },
+                                            "loadBehavior": "PreLoad",
                                             "assetHint": "scriptcanvas/paper_kid_script_events.scriptevents"
                                         },
                                         "m_busId": {
@@ -2020,7 +2040,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13519292988236
+                                    "id": 222834762960640
                                 },
                                 "Name": "SC-Node(GetOnTriggerEnterEvent)",
                                 "Components": {
@@ -2097,6 +2117,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -2105,7 +2126,7 @@
                                                 "value": {
                                                     "id": 2901262558
                                                 },
-                                                "label": "EntityId"
+                                                "label": "Entity Id"
                                             }
                                         ],
                                         "methodType": 2,
@@ -2125,7 +2146,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13618077236044
+                                    "id": 222860532764416
                                 },
                                 "Name": "SC-EventNode(On Trigger Enter event)",
                                 "Components": {
@@ -2148,7 +2169,7 @@
                                                     {
                                                         "$type": "RestrictedNodeContract",
                                                         "m_nodeId": {
-                                                            "id": 13519292988236
+                                                            "id": 222834762960640
                                                         }
                                                     }
                                                 ],
@@ -2279,7 +2300,7 @@
                                                     {
                                                         "$type": "RestrictedNodeContract",
                                                         "m_nodeId": {
-                                                            "id": 13519292988236
+                                                            "id": 222834762960640
                                                         }
                                                     }
                                                 ],
@@ -2322,7 +2343,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13643847039820
+                                    "id": 222882007600896
                                 },
                                 "Name": "SC-Node(TimeDelayNodeableNode)",
                                 "Components": {
@@ -2409,6 +2430,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -2458,7 +2480,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13476343315276
+                                    "id": 222916367339264
                                 },
                                 "Name": "SC-Node(GetParentId)",
                                 "Components": {
@@ -2534,6 +2556,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -2562,7 +2585,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13493523184460
+                                    "id": 222985086816000
                                 },
                                 "Name": "SC-Node(GetParentId)",
                                 "Components": {
@@ -2638,6 +2661,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -2666,7 +2690,106 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13536472857420
+                                    "id": 514901129023232
+                                },
+                                "Name": "SC-Node(GetOtherEntityId)",
+                                "Components": {
+                                    "Component_[15374500770998360039]": {
+                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
+                                        "Id": 15374500770998360039,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{A96105BA-25E3-4362-B46C-0A517B8D9CB0}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "TriggerEvent",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{29589F1A-BA42-44A5-B191-A6163C9A1E39}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{E1249F98-FB16-4D6C-AA6E-583CADE512A5}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{BC183546-38BB-44C9-83C9-9C963A24C2D6}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId",
+                                                "DisplayDataType": {
+                                                    "m_type": 1
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{7A0851A3-2CBD-4A03-85D5-1C40221E7F61}"
+                                                },
+                                                "isNullPointer": true,
+                                                "label": "Trigger Event"
+                                            }
+                                        ],
+                                        "methodType": 2,
+                                        "methodName": "GetOtherEntityId",
+                                        "className": "TriggerEvent",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{A96105BA-25E3-4362-B46C-0A517B8D9CB0}"
+                                            }
+                                        ],
+                                        "prettyClassName": "TriggerEvent"
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 222950727077632
                                 },
                                 "Name": "SC-Node(ForEach)",
                                 "Components": {
@@ -2784,6 +2907,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
@@ -2813,7 +2937,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13506408086348
+                                    "id": 222903482437376
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -2891,6 +3015,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -2914,7 +3039,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13609487301452
+                                    "id": 222826173026048
                                 },
                                 "Name": "SC-Node(Not)",
                                 "Components": {
@@ -3012,6 +3137,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -3026,7 +3152,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13532177890124
+                                    "id": 222851942829824
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -3104,6 +3230,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -3127,7 +3254,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 248054572120908
+                                    "id": 222877712633600
                                 },
                                 "Name": "SC-Node(GetEntityName)",
                                 "Components": {
@@ -3218,6 +3345,9 @@
                                         "methodType": 0,
                                         "methodName": "GetEntityName",
                                         "className": "ComponentApplicationBus",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
                                         "inputSlots": [
                                             {
                                                 "m_id": "{31FE371C-2170-451C-9B38-67089766514A}"
@@ -3229,110 +3359,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 245756764617548
-                                },
-                                "Name": "SC-Node(GetChildren)",
-                                "Components": {
-                                    "Component_[18191661702195618806]": {
-                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
-                                        "Id": 18191661702195618806,
-                                        "Slots": [
-                                            {
-                                                "id": {
-                                                    "m_id": "{CEFE0879-54BC-476B-9815-A97966D1969B}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "EntityId",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{6B47290C-3C65-43F3-B5BA-BE73F1845808}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "In",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{18C1DF8F-48FD-480D-9364-D501C4AE7E1F}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Out",
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{25B7839F-E43B-4C81-B565-DD0C30B44A65}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Array<EntityId>",
-                                                "DisplayDataType": {
-                                                    "m_type": 4,
-                                                    "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            }
-                                        ],
-                                        "Datums": [
-                                            {
-                                                "isOverloadedStorage": false,
-                                                "scriptCanvasType": {
-                                                    "m_type": 1
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "EntityId",
-                                                "value": {
-                                                    "id": 2901262558
-                                                },
-                                                "label": "EntityId"
-                                            }
-                                        ],
-                                        "methodType": 0,
-                                        "methodName": "GetChildren",
-                                        "className": "TransformBus",
-                                        "inputSlots": [
-                                            {
-                                                "m_id": "{CEFE0879-54BC-476B-9815-A97966D1969B}"
-                                            }
-                                        ],
-                                        "prettyClassName": "TransformBus"
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 305830472186700
+                                    "id": 222912072371968
                                 },
                                 "Name": "SC-Node(GetChildren)",
                                 "Components": {
@@ -3438,7 +3465,113 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13600897366860
+                                    "id": 222980791848704
+                                },
+                                "Name": "SC-Node(GetChildren)",
+                                "Components": {
+                                    "Component_[18191661702195618806]": {
+                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
+                                        "Id": 18191661702195618806,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{CEFE0879-54BC-476B-9815-A97966D1969B}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "EntityId",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{6B47290C-3C65-43F3-B5BA-BE73F1845808}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{18C1DF8F-48FD-480D-9364-D501C4AE7E1F}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{25B7839F-E43B-4C81-B565-DD0C30B44A65}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Array<EntityId>",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 1
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "EntityId",
+                                                "value": {
+                                                    "id": 2901262558
+                                                },
+                                                "label": "EntityId"
+                                            }
+                                        ],
+                                        "methodType": 0,
+                                        "methodName": "GetChildren",
+                                        "className": "TransformBus",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{CEFE0879-54BC-476B-9815-A97966D1969B}"
+                                            }
+                                        ],
+                                        "prettyClassName": "TransformBus"
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 222942137143040
                                 },
                                 "Name": "SC-Node(Gate)",
                                 "Components": {
@@ -3518,6 +3651,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -3532,7 +3666,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13605192334156
+                                    "id": 222946432110336
                                 },
                                 "Name": "SC-Node(Gate)",
                                 "Components": {
@@ -3612,6 +3746,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -3626,7 +3761,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13566537628492
+                                    "id": 222976496881408
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -3704,6 +3839,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -3729,7 +3865,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13630962137932
+                                    "id": 222821878058752
                                 },
                                 "Name": "SC-Node(GetParentId)",
                                 "Components": {
@@ -3805,6 +3941,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -3833,7 +3970,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 303751708015436
+                                    "id": 222847647862528
                                 },
                                 "Name": "SC-Node(Get First Element)",
                                 "Components": {
@@ -3937,12 +4074,12 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
                                                 },
-                                                "isNullPointer": true,
+                                                "isNullPointer": false,
+                                                "$type": "{4841CFF0-7A5C-519C-BD16-D3625E99605E} AZStd::vector<EntityId, allocator>",
                                                 "label": "Container"
                                             }
                                         ],
@@ -3969,7 +4106,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 305826177219404
+                                    "id": 222873417666304
                                 },
                                 "Name": "SC-Node(Get First Element)",
                                 "Components": {
@@ -4073,12 +4210,12 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
                                                 },
-                                                "isNullPointer": true,
+                                                "isNullPointer": false,
+                                                "$type": "{4841CFF0-7A5C-519C-BD16-D3625E99605E} AZStd::vector<EntityId, allocator>",
                                                 "label": "Container"
                                             }
                                         ],
@@ -4105,7 +4242,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13502113119052
+                                    "id": 222894892502784
                                 },
                                 "Name": "SC-Node(DeactivateGameEntity)",
                                 "Components": {
@@ -4162,6 +4299,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -4190,7 +4328,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13557947693900
+                                    "id": 223002266685184
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -4268,6 +4406,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -4291,7 +4430,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13635257105228
+                                    "id": 222933547208448
                                 },
                                 "Name": "SC-Node(GetEntityName)",
                                 "Components": {
@@ -4367,6 +4506,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -4395,7 +4535,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13489228217164
+                                    "id": 222967906946816
                                 },
                                 "Name": "ReceiveScriptEvent",
                                 "Components": {
@@ -4684,6 +4824,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -4693,6 +4834,7 @@
                                                 "label": "String"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -4880,6 +5022,7 @@
                                             "assetId": {
                                                 "guid": "{192B5ACD-AA8B-5097-A03F-8F25DC7733CE}"
                                             },
+                                            "loadBehavior": "PreLoad",
                                             "assetHint": "scriptcanvas/paper_kid_script_events.scriptevents"
                                         },
                                         "m_autoConnectToGraphOwner": false
@@ -4888,7 +5031,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13472048347980
+                                    "id": 222813288124160
                                 },
                                 "Name": "EBusEventHandler",
                                 "Components": {
@@ -5066,6 +5209,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -5128,7 +5272,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13583717497676
+                                    "id": 222839057927936
                                 },
                                 "Name": "SC-Node(Get Element)",
                                 "Components": {
@@ -5256,6 +5400,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 4,
                                                     "m_azType": "{99DAD0BC-740E-5E82-826B-8FC7968CC02C}"
@@ -5265,6 +5410,7 @@
                                                 "label": "Container"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 3
                                                 },
@@ -5303,7 +5449,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 446838543481676
+                                    "id": 222864827731712
                                 },
                                 "Name": "SC-Node(SetVisibility)",
                                 "Components": {
@@ -5405,6 +5551,9 @@
                                         "methodType": 0,
                                         "methodName": "SetVisibility",
                                         "className": "RenderMeshComponentRequestBus",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
                                         "inputSlots": [
                                             {
                                                 "m_id": "{70BA44BF-7B75-4F91-B0B2-EDD58D5E74DA}"
@@ -5419,7 +5568,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13523587955532
+                                    "id": 222886302568192
                                 },
                                 "Name": "SC-Node(ScriptCanvas_StringFunctions_EndsWith)",
                                 "Components": {
@@ -5546,6 +5695,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -5555,6 +5705,7 @@
                                                 "label": "Source"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -5564,6 +5715,7 @@
                                                 "label": "Pattern"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -5595,109 +5747,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13622372203340
-                                },
-                                "Name": "SC-Node(Get Other EntityId)",
-                                "Components": {
-                                    "Component_[6895667073360229519]": {
-                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
-                                        "Id": 6895667073360229519,
-                                        "Slots": [
-                                            {
-                                                "id": {
-                                                    "m_id": "{8B33312B-ECDE-4C67-93B5-E0410F94718B}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "TriggerEvent",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{05A0C04F-66C9-4D0C-B727-CF30C470F38D}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "In",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{9C2D2FEA-9F5B-401C-9F50-C9C9048A57E8}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Out",
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{3A4CD578-3C4F-48EC-B0AC-06743F95935A}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "EntityId",
-                                                "DisplayDataType": {
-                                                    "m_type": 1
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            }
-                                        ],
-                                        "Datums": [
-                                            {
-                                                "scriptCanvasType": {
-                                                    "m_type": 4,
-                                                    "m_azType": "{7A0851A3-2CBD-4A03-85D5-1C40221E7F61}"
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "TriggerEvent",
-                                                "label": "TriggerEvent"
-                                            }
-                                        ],
-                                        "methodType": 2,
-                                        "methodName": "Get Other EntityId",
-                                        "className": "TriggerEvent",
-                                        "resultSlotIDs": [
-                                            {}
-                                        ],
-                                        "inputSlots": [
-                                            {
-                                                "m_id": "{8B33312B-ECDE-4C67-93B5-E0410F94718B}"
-                                            }
-                                        ],
-                                        "prettyClassName": "TriggerEvent"
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 13480638282572
+                                    "id": 222924957273856
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -5775,6 +5825,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -5798,7 +5849,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13497818151756
+                                    "id": 222959317012224
                                 },
                                 "Name": "SC-Node(ScriptCanvas_StringFunctions_StartsWith)",
                                 "Components": {
@@ -5925,6 +5976,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -5934,6 +5986,7 @@
                                                 "label": "Source"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 5
                                                 },
@@ -5943,6 +5996,7 @@
                                                 "label": "Pattern"
                                             },
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -5974,7 +6028,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13514998020940
+                                    "id": 222907777404672
                                 },
                                 "Name": "SC-Node(GetEntityName)",
                                 "Components": {
@@ -6050,6 +6104,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -6078,7 +6133,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13553652726604
+                                    "id": 222830467993344
                                 },
                                 "Name": "SC-Node(GetChildren)",
                                 "Components": {
@@ -6155,6 +6210,7 @@
                                         ],
                                         "Datums": [
                                             {
+                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -6183,7 +6239,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 205285287787340
+                                    "id": 222856237797120
                                 },
                                 "Name": "SC-Node(SetVisibility)",
                                 "Components": {
@@ -6285,6 +6341,9 @@
                                         "methodType": 0,
                                         "methodName": "SetVisibility",
                                         "className": "RenderMeshComponentRequestBus",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
                                         "inputSlots": [
                                             {
                                                 "m_id": "{7F1D5EC9-AEDB-4453-B628-EE0FB1B4315D}"
@@ -6301,7 +6360,7 @@
                         "m_connections": [
                             {
                                 "Id": {
-                                    "id": 13652436974412
+                                    "id": 223006561652480
                                 },
                                 "Name": "srcEndpoint=(GetOnTriggerEnterEvent: Event<AZStd::tuple<Crc32, int>, const TriggerEvent&>), destEndpoint=(On Trigger Enter event: On Trigger Enter event)",
                                 "Components": {
@@ -6310,7 +6369,7 @@
                                         "Id": 8537832985444168507,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13519292988236
+                                                "id": 222834762960640
                                             },
                                             "slotId": {
                                                 "m_id": "{19AABC8C-2B82-4D3D-85F0-4B9381B204FB}"
@@ -6318,7 +6377,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13618077236044
+                                                "id": 222860532764416
                                             },
                                             "slotId": {
                                                 "m_id": "{CCBF7196-8036-48D6-A4E3-00D2C302494B}"
@@ -6329,7 +6388,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13656731941708
+                                    "id": 223010856619776
                                 },
                                 "Name": "srcEndpoint=(GetOnTriggerEnterEvent: Out), destEndpoint=(On Trigger Enter event: Connect)",
                                 "Components": {
@@ -6338,7 +6397,7 @@
                                         "Id": 15046492396959185944,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13519292988236
+                                                "id": 222834762960640
                                             },
                                             "slotId": {
                                                 "m_id": "{40B0E3DB-3848-47F1-9B6B-05F951B99DF3}"
@@ -6346,7 +6405,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13618077236044
+                                                "id": 222860532764416
                                             },
                                             "slotId": {
                                                 "m_id": "{954EAFB9-5B35-4863-BF30-438832F16777}"
@@ -6357,7 +6416,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13661026909004
+                                    "id": 223015151587072
                                 },
                                 "Name": "srcEndpoint=(EntityBus Handler: ExecutionSlot:OnEntityActivated), destEndpoint=(GetOnTriggerEnterEvent: In)",
                                 "Components": {
@@ -6366,7 +6425,7 @@
                                         "Id": 14482555147227343367,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13472048347980
+                                                "id": 222813288124160
                                             },
                                             "slotId": {
                                                 "m_id": "{55D318BB-A620-4F6A-BDD7-20266D92CBE3}"
@@ -6374,7 +6433,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13519292988236
+                                                "id": 222834762960640
                                             },
                                             "slotId": {
                                                 "m_id": "{10279785-48A4-4640-B710-0D39C9BA4170}"
@@ -6385,119 +6444,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13665321876300
-                                },
-                                "Name": "srcEndpoint=(On Trigger Enter event: OnEvent), destEndpoint=(Get Other EntityId: In)",
-                                "Components": {
-                                    "Component_[2315258841885451204]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 2315258841885451204,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 13618077236044
-                                            },
-                                            "slotId": {
-                                                "m_id": "{B7D21051-E978-4A0B-ADF8-A69E865FFF9D}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 13622372203340
-                                            },
-                                            "slotId": {
-                                                "m_id": "{05A0C04F-66C9-4D0C-B727-CF30C470F38D}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 13669616843596
-                                },
-                                "Name": "srcEndpoint=(On Trigger Enter event: Trigger Event), destEndpoint=(Get Other EntityId: TriggerEvent)",
-                                "Components": {
-                                    "Component_[5438179246453382022]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 5438179246453382022,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 13618077236044
-                                            },
-                                            "slotId": {
-                                                "m_id": "{81922A76-4BFE-4EB4-8929-28DE937AAB21}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 13622372203340
-                                            },
-                                            "slotId": {
-                                                "m_id": "{8B33312B-ECDE-4C67-93B5-E0410F94718B}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 13673911810892
-                                },
-                                "Name": "srcEndpoint=(Get Other EntityId: Out), destEndpoint=(GetEntityName: In)",
-                                "Components": {
-                                    "Component_[2926312176930601949]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 2926312176930601949,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 13622372203340
-                                            },
-                                            "slotId": {
-                                                "m_id": "{9C2D2FEA-9F5B-401C-9F50-C9C9048A57E8}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 13635257105228
-                                            },
-                                            "slotId": {
-                                                "m_id": "{986A3CC3-3C87-41F7-A00C-55587DABB350}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 13678206778188
-                                },
-                                "Name": "srcEndpoint=(Get Other EntityId: EntityId), destEndpoint=(GetEntityName: EntityId)",
-                                "Components": {
-                                    "Component_[12585397334306086634]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 12585397334306086634,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 13622372203340
-                                            },
-                                            "slotId": {
-                                                "m_id": "{3A4CD578-3C4F-48EC-B0AC-06743F95935A}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 13635257105228
-                                            },
-                                            "slotId": {
-                                                "m_id": "{1127602F-F67C-4C0E-9988-C349650276A3}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 13682501745484
+                                    "id": 223036626423552
                                 },
                                 "Name": "srcEndpoint=(GetEntityName: Out), destEndpoint=(ScriptCanvas_StringFunctions_EndsWith: In)",
                                 "Components": {
@@ -6506,7 +6453,7 @@
                                         "Id": 3898662456822082529,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13635257105228
+                                                "id": 222933547208448
                                             },
                                             "slotId": {
                                                 "m_id": "{947729F7-7752-4F73-A584-255BA3FC231C}"
@@ -6514,7 +6461,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13626667170636
+                                                "id": 222929252241152
                                             },
                                             "slotId": {
                                                 "m_id": "{3E2CDE5F-CCA7-4A78-BA3B-9DFE13093918}"
@@ -6525,7 +6472,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13686796712780
+                                    "id": 223040921390848
                                 },
                                 "Name": "srcEndpoint=(GetEntityName: String), destEndpoint=(ScriptCanvas_StringFunctions_EndsWith: Source)",
                                 "Components": {
@@ -6534,7 +6481,7 @@
                                         "Id": 7185989264774025078,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13635257105228
+                                                "id": 222933547208448
                                             },
                                             "slotId": {
                                                 "m_id": "{27150FF5-8B09-4E0F-B37A-2B85CF39C004}"
@@ -6542,7 +6489,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13626667170636
+                                                "id": 222929252241152
                                             },
                                             "slotId": {
                                                 "m_id": "{5FBBA5E0-F942-4A75-A08F-69434A9E0F99}"
@@ -6553,7 +6500,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13691091680076
+                                    "id": 223045216358144
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_StringFunctions_EndsWith: True), destEndpoint=(DeactivateGameEntity: In)",
                                 "Components": {
@@ -6562,7 +6509,7 @@
                                         "Id": 16827167778195568168,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13626667170636
+                                                "id": 222929252241152
                                             },
                                             "slotId": {
                                                 "m_id": "{B541231A-30E5-4397-A831-5525AF80C682}"
@@ -6570,7 +6517,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13502113119052
+                                                "id": 222894892502784
                                             },
                                             "slotId": {
                                                 "m_id": "{7B692ADB-5C9D-4536-8FC2-13D3DFB442D7}"
@@ -6581,35 +6528,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13695386647372
-                                },
-                                "Name": "srcEndpoint=(Get Other EntityId: EntityId), destEndpoint=(DeactivateGameEntity: EntityId)",
-                                "Components": {
-                                    "Component_[7445398558357776616]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 7445398558357776616,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 13622372203340
-                                            },
-                                            "slotId": {
-                                                "m_id": "{3A4CD578-3C4F-48EC-B0AC-06743F95935A}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 13502113119052
-                                            },
-                                            "slotId": {
-                                                "m_id": "{84E620D8-3AC5-4077-9A05-DAB66CFB421B}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 13699681614668
+                                    "id": 223053806292736
                                 },
                                 "Name": "srcEndpoint=(GetEntityName: Out), destEndpoint=(ScriptCanvas_StringFunctions_Split: In)",
                                 "Components": {
@@ -6618,7 +6537,7 @@
                                         "Id": 10754469911080625042,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13514998020940
+                                                "id": 222907777404672
                                             },
                                             "slotId": {
                                                 "m_id": "{E8A08BD8-A889-4BE5-97CB-225DF0F96B30}"
@@ -6626,7 +6545,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13545062792012
+                                                "id": 222869122699008
                                             },
                                             "slotId": {
                                                 "m_id": "{7F82FB1B-6FFC-4A1C-A727-FE2BB6638624}"
@@ -6637,7 +6556,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13703976581964
+                                    "id": 223058101260032
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_StringFunctions_Split: Array<String>), destEndpoint=(Get Element: Container)",
                                 "Components": {
@@ -6646,7 +6565,7 @@
                                         "Id": 18186027746772135623,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13545062792012
+                                                "id": 222869122699008
                                             },
                                             "slotId": {
                                                 "m_id": "{0B746C04-F29A-4892-B0B2-E468428ABA2D}"
@@ -6654,7 +6573,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13583717497676
+                                                "id": 222839057927936
                                             },
                                             "slotId": {
                                                 "m_id": "{9B3FD6DC-4143-4DC8-9E4F-C4C85B7B13D3}"
@@ -6665,7 +6584,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13708271549260
+                                    "id": 223062396227328
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_StringFunctions_Split: Out), destEndpoint=(Get Element: In)",
                                 "Components": {
@@ -6674,7 +6593,7 @@
                                         "Id": 3739109416739315059,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13545062792012
+                                                "id": 222869122699008
                                             },
                                             "slotId": {
                                                 "m_id": "{27D0999B-F0B0-4B4E-8268-DA72C2B8099D}"
@@ -6682,7 +6601,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13583717497676
+                                                "id": 222839057927936
                                             },
                                             "slotId": {
                                                 "m_id": "{FF273D8F-51E4-4ABA-993A-656123B6A645}"
@@ -6693,7 +6612,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13712566516556
+                                    "id": 223066691194624
                                 },
                                 "Name": "srcEndpoint=(Get Element: Out), destEndpoint=(ScriptCanvas_MathFunctions_StringToNumber: In)",
                                 "Components": {
@@ -6702,7 +6621,7 @@
                                         "Id": 3064765503676022460,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13583717497676
+                                                "id": 222839057927936
                                             },
                                             "slotId": {
                                                 "m_id": "{ECB61DA2-22DD-4F3C-BF7F-B0E2F554B94A}"
@@ -6710,7 +6629,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13510703053644
+                                                "id": 222963611979520
                                             },
                                             "slotId": {
                                                 "m_id": "{360255AB-7157-4B24-9259-6F3FAD40314E}"
@@ -6721,7 +6640,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13716861483852
+                                    "id": 223070986161920
                                 },
                                 "Name": "srcEndpoint=(Get Element: Value), destEndpoint=(ScriptCanvas_MathFunctions_StringToNumber: Value)",
                                 "Components": {
@@ -6730,7 +6649,7 @@
                                         "Id": 16778367387881745186,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13583717497676
+                                                "id": 222839057927936
                                             },
                                             "slotId": {
                                                 "m_id": "{61CAEC76-1CF3-484E-BF8D-396ED2678F65}"
@@ -6738,7 +6657,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13510703053644
+                                                "id": 222963611979520
                                             },
                                             "slotId": {
                                                 "m_id": "{344D724F-E41B-4812-8FA5-06399BE043B5}"
@@ -6749,7 +6668,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13721156451148
+                                    "id": 223075281129216
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_MathFunctions_StringToNumber: Out), destEndpoint=(Send Script Event: In)",
                                 "Components": {
@@ -6758,7 +6677,7 @@
                                         "Id": 4819320633994883759,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13510703053644
+                                                "id": 222963611979520
                                             },
                                             "slotId": {
                                                 "m_id": "{10043290-9328-417B-89A3-2B486FD012E4}"
@@ -6766,7 +6685,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13570832595788
+                                                "id": 222808993156864
                                             },
                                             "slotId": {
                                                 "m_id": "{F15EE588-4D3C-4F3A-8309-659745E6B30A}"
@@ -6777,7 +6696,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13725451418444
+                                    "id": 223079576096512
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_MathFunctions_StringToNumber: Number), destEndpoint=(Send Script Event: Points)",
                                 "Components": {
@@ -6786,7 +6705,7 @@
                                         "Id": 16526284529838953234,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13510703053644
+                                                "id": 222963611979520
                                             },
                                             "slotId": {
                                                 "m_id": "{8F31F6D8-91CB-4E0D-AFB7-597D9D060474}"
@@ -6794,7 +6713,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13570832595788
+                                                "id": 222808993156864
                                             },
                                             "slotId": {
                                                 "m_id": "{0B4F4B36-2F6E-443F-9BA1-CAF5681919FE}"
@@ -6805,7 +6724,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13729746385740
+                                    "id": 223083871063808
                                 },
                                 "Name": "srcEndpoint=(GetEntityName: String), destEndpoint=(ScriptCanvas_StringFunctions_Split: Source)",
                                 "Components": {
@@ -6814,7 +6733,7 @@
                                         "Id": 395967884839485943,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13514998020940
+                                                "id": 222907777404672
                                             },
                                             "slotId": {
                                                 "m_id": "{FFF54280-57EB-4B31-94CF-2B1059C846FC}"
@@ -6822,7 +6741,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13545062792012
+                                                "id": 222869122699008
                                             },
                                             "slotId": {
                                                 "m_id": "{487330D1-165E-4DD5-B674-ABCDDA45559A}"
@@ -6833,7 +6752,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13734041353036
+                                    "id": 223088166031104
                                 },
                                 "Name": "srcEndpoint=(GetParentId: Out), destEndpoint=(GetEntityName: In)",
                                 "Components": {
@@ -6842,7 +6761,7 @@
                                         "Id": 3544951605027083743,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13630962137932
+                                                "id": 222821878058752
                                             },
                                             "slotId": {
                                                 "m_id": "{209C005B-84E8-4F83-85CF-4CAE46FA538D}"
@@ -6850,7 +6769,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13514998020940
+                                                "id": 222907777404672
                                             },
                                             "slotId": {
                                                 "m_id": "{CA3FCF64-6B8B-4F24-8051-E1DC68DF29DF}"
@@ -6861,7 +6780,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13738336320332
+                                    "id": 223092460998400
                                 },
                                 "Name": "srcEndpoint=(GetParentId: EntityId), destEndpoint=(GetEntityName: EntityId)",
                                 "Components": {
@@ -6870,7 +6789,7 @@
                                         "Id": 10543991193543095117,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13630962137932
+                                                "id": 222821878058752
                                             },
                                             "slotId": {
                                                 "m_id": "{F1ACE4C2-7821-4419-9F7E-616989E0BCFA}"
@@ -6878,7 +6797,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13514998020940
+                                                "id": 222907777404672
                                             },
                                             "slotId": {
                                                 "m_id": "{BFB50220-ED31-43EE-8B17-73943D961384}"
@@ -6889,7 +6808,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13742631287628
+                                    "id": 223096755965696
                                 },
                                 "Name": "srcEndpoint=(DeactivateGameEntity: Out), destEndpoint=(If: In)",
                                 "Components": {
@@ -6898,7 +6817,7 @@
                                         "Id": 3859202099392043297,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13502113119052
+                                                "id": 222894892502784
                                             },
                                             "slotId": {
                                                 "m_id": "{EDA2780A-8BB4-4C3B-B13B-A453D3DB3B6D}"
@@ -6906,7 +6825,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13605192334156
+                                                "id": 222942137143040
                                             },
                                             "slotId": {
                                                 "m_id": "{3DEFF1AA-6105-44F1-84A9-032E54EE3EAC}"
@@ -6917,7 +6836,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13746926254924
+                                    "id": 223101050932992
                                 },
                                 "Name": "srcEndpoint=(Send Script Event: Out), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -6926,7 +6845,7 @@
                                         "Id": 2774862659666078724,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13570832595788
+                                                "id": 222808993156864
                                             },
                                             "slotId": {
                                                 "m_id": "{6EFBC74F-673A-41C8-A0DF-05E574D403F0}"
@@ -6934,7 +6853,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13532177890124
+                                                "id": 222851942829824
                                             },
                                             "slotId": {
                                                 "m_id": "{4B0E0B25-BDAF-4F2F-9C33-C25A05FB441D}"
@@ -6945,7 +6864,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13751221222220
+                                    "id": 223105345900288
                                 },
                                 "Name": "srcEndpoint=(EntityBus Handler: ExecutionSlot:OnEntityActivated), destEndpoint=(Receive Script Event: Connect)",
                                 "Components": {
@@ -6954,7 +6873,7 @@
                                         "Id": 5959974706959923715,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13472048347980
+                                                "id": 222813288124160
                                             },
                                             "slotId": {
                                                 "m_id": "{55D318BB-A620-4F6A-BDD7-20266D92CBE3}"
@@ -6962,7 +6881,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13596602399564
+                                                "id": 222899187470080
                                             },
                                             "slotId": {
                                                 "m_id": "{6AFF0D27-FA2A-451F-B1E3-7C8024975D22}"
@@ -6973,7 +6892,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13755516189516
+                                    "id": 223109640867584
                                 },
                                 "Name": "srcEndpoint=(EntityBus Handler: ExecutionSlot:OnEntityActivated), destEndpoint=(Receive Script Event: Connect)",
                                 "Components": {
@@ -6982,7 +6901,7 @@
                                         "Id": 18230262549033070439,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13472048347980
+                                                "id": 222813288124160
                                             },
                                             "slotId": {
                                                 "m_id": "{55D318BB-A620-4F6A-BDD7-20266D92CBE3}"
@@ -6990,7 +6909,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13489228217164
+                                                "id": 222967906946816
                                             },
                                             "slotId": {
                                                 "m_id": "{5510F0C1-B5EA-441B-BEB7-754AAF465E61}"
@@ -7001,7 +6920,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13759811156812
+                                    "id": 223113935834880
                                 },
                                 "Name": "srcEndpoint=(Receive Script Event: ExecutionSlot:NextLevel), destEndpoint=(If: In)",
                                 "Components": {
@@ -7010,7 +6929,7 @@
                                         "Id": 6117055363287133771,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13489228217164
+                                                "id": 222967906946816
                                             },
                                             "slotId": {
                                                 "m_id": "{D34A57A9-547E-41E1-A512-8DA5B6ABF1A5}"
@@ -7018,7 +6937,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13600897366860
+                                                "id": 222946432110336
                                             },
                                             "slotId": {
                                                 "m_id": "{3DEFF1AA-6105-44F1-84A9-032E54EE3EAC}"
@@ -7029,7 +6948,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13764106124108
+                                    "id": 223118230802176
                                 },
                                 "Name": "srcEndpoint=(If: False), destEndpoint=(Not: In)",
                                 "Components": {
@@ -7038,7 +6957,7 @@
                                         "Id": 16771504789012701653,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13605192334156
+                                                "id": 222942137143040
                                             },
                                             "slotId": {
                                                 "m_id": "{BA4F221D-464A-44F4-9154-C70F62B6E1A1}"
@@ -7046,7 +6965,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13609487301452
+                                                "id": 222826173026048
                                             },
                                             "slotId": {
                                                 "m_id": "{3D07EE76-25E6-449A-9F09-DBAF3D8B4078}"
@@ -7057,7 +6976,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13768401091404
+                                    "id": 223122525769472
                                 },
                                 "Name": "srcEndpoint=(Not: True), destEndpoint=(GetParentId: In)",
                                 "Components": {
@@ -7066,7 +6985,7 @@
                                         "Id": 6381237912248417897,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13609487301452
+                                                "id": 222826173026048
                                             },
                                             "slotId": {
                                                 "m_id": "{D2537662-E26C-404F-B800-E8C5926CA56C}"
@@ -7074,7 +6993,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13630962137932
+                                                "id": 222821878058752
                                             },
                                             "slotId": {
                                                 "m_id": "{2840C8A0-80BE-47A0-B738-90B0646E3F7E}"
@@ -7085,7 +7004,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13772696058700
+                                    "id": 223126820736768
                                 },
                                 "Name": "srcEndpoint=(EntityBus Handler: ExecutionSlot:OnEntityActivated), destEndpoint=(TimeDelay: Start)",
                                 "Components": {
@@ -7094,7 +7013,7 @@
                                         "Id": 7656763149158486439,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13472048347980
+                                                "id": 222813288124160
                                             },
                                             "slotId": {
                                                 "m_id": "{55D318BB-A620-4F6A-BDD7-20266D92CBE3}"
@@ -7102,7 +7021,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13643847039820
+                                                "id": 222882007600896
                                             },
                                             "slotId": {
                                                 "m_id": "{7FCF4933-78EF-4493-B285-56B9CEC57E03}"
@@ -7113,7 +7032,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13776991025996
+                                    "id": 223131115704064
                                 },
                                 "Name": "srcEndpoint=(TimeDelay: Done), destEndpoint=(GetParentId: In)",
                                 "Components": {
@@ -7122,7 +7041,7 @@
                                         "Id": 3961320165755382581,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13643847039820
+                                                "id": 222882007600896
                                             },
                                             "slotId": {
                                                 "m_id": "{C0C2AE43-D89B-4040-9421-90D345467985}"
@@ -7130,7 +7049,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13476343315276
+                                                "id": 222985086816000
                                             },
                                             "slotId": {
                                                 "m_id": "{C785E74C-B8A5-4432-AF84-A1A663E29B1E}"
@@ -7141,7 +7060,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13781285993292
+                                    "id": 223135410671360
                                 },
                                 "Name": "srcEndpoint=(GetParentId: Out), destEndpoint=(GetParentId: In)",
                                 "Components": {
@@ -7150,7 +7069,7 @@
                                         "Id": 18111828351943622284,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13476343315276
+                                                "id": 222985086816000
                                             },
                                             "slotId": {
                                                 "m_id": "{83A613B2-62B3-4571-BF91-854C8B90466E}"
@@ -7158,7 +7077,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13493523184460
+                                                "id": 222916367339264
                                             },
                                             "slotId": {
                                                 "m_id": "{C785E74C-B8A5-4432-AF84-A1A663E29B1E}"
@@ -7169,7 +7088,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13785580960588
+                                    "id": 223139705638656
                                 },
                                 "Name": "srcEndpoint=(GetParentId: EntityId), destEndpoint=(GetParentId: EntityId)",
                                 "Components": {
@@ -7178,7 +7097,7 @@
                                         "Id": 10173806815908761112,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13476343315276
+                                                "id": 222985086816000
                                             },
                                             "slotId": {
                                                 "m_id": "{BF0216B6-1DEB-4140-BC61-A9A1FD6AA8A8}"
@@ -7186,7 +7105,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13493523184460
+                                                "id": 222916367339264
                                             },
                                             "slotId": {
                                                 "m_id": "{8655A30C-588F-4A31-91BD-892E11145E9A}"
@@ -7197,7 +7116,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13789875927884
+                                    "id": 223144000605952
                                 },
                                 "Name": "srcEndpoint=(GetParentId: Out), destEndpoint=(GetChildren: In)",
                                 "Components": {
@@ -7206,7 +7125,7 @@
                                         "Id": 16220127211876162256,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13493523184460
+                                                "id": 222916367339264
                                             },
                                             "slotId": {
                                                 "m_id": "{83A613B2-62B3-4571-BF91-854C8B90466E}"
@@ -7214,7 +7133,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13553652726604
+                                                "id": 222830467993344
                                             },
                                             "slotId": {
                                                 "m_id": "{235D780D-FE18-4E3A-BDB0-69872CA4862A}"
@@ -7225,7 +7144,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13794170895180
+                                    "id": 223148295573248
                                 },
                                 "Name": "srcEndpoint=(GetParentId: EntityId), destEndpoint=(GetChildren: EntityId)",
                                 "Components": {
@@ -7234,7 +7153,7 @@
                                         "Id": 5351837651705669161,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13493523184460
+                                                "id": 222916367339264
                                             },
                                             "slotId": {
                                                 "m_id": "{BF0216B6-1DEB-4140-BC61-A9A1FD6AA8A8}"
@@ -7242,7 +7161,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13553652726604
+                                                "id": 222830467993344
                                             },
                                             "slotId": {
                                                 "m_id": "{13BBF31D-6497-4823-AF11-29191BC86AF6}"
@@ -7253,7 +7172,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13798465862476
+                                    "id": 223152590540544
                                 },
                                 "Name": "srcEndpoint=(GetChildren: Out), destEndpoint=(For Each: In)",
                                 "Components": {
@@ -7262,7 +7181,7 @@
                                         "Id": 8358065728865810922,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13553652726604
+                                                "id": 222830467993344
                                             },
                                             "slotId": {
                                                 "m_id": "{80BBD067-BF31-4ADD-BBA3-505B88CD716C}"
@@ -7270,7 +7189,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13536472857420
+                                                "id": 222950727077632
                                             },
                                             "slotId": {
                                                 "m_id": "{AEF8567D-99F9-4B88-B17C-CB4837A6D075}"
@@ -7281,7 +7200,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13802760829772
+                                    "id": 223156885507840
                                 },
                                 "Name": "srcEndpoint=(GetChildren: Array<EntityId>), destEndpoint=(For Each: Source)",
                                 "Components": {
@@ -7290,7 +7209,7 @@
                                         "Id": 14577140670494433185,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13553652726604
+                                                "id": 222830467993344
                                             },
                                             "slotId": {
                                                 "m_id": "{673A8852-6A2D-4F34-94F2-2422C62BDD64}"
@@ -7298,7 +7217,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13536472857420
+                                                "id": 222950727077632
                                             },
                                             "slotId": {
                                                 "m_id": "{E5E06D76-AEAD-4745-A5BE-82C4C10676CD}"
@@ -7309,7 +7228,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13807055797068
+                                    "id": 223161180475136
                                 },
                                 "Name": "srcEndpoint=(For Each: Each), destEndpoint=(GetEntityName: In)",
                                 "Components": {
@@ -7318,7 +7237,7 @@
                                         "Id": 10595078278576164781,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13536472857420
+                                                "id": 222950727077632
                                             },
                                             "slotId": {
                                                 "m_id": "{19AF2C8B-5E6C-4CF6-BD63-83C5B8EB8670}"
@@ -7326,7 +7245,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13579422530380
+                                                "id": 222937842175744
                                             },
                                             "slotId": {
                                                 "m_id": "{971AE031-6740-4723-9377-7753AFAB4A41}"
@@ -7337,7 +7256,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13811350764364
+                                    "id": 223165475442432
                                 },
                                 "Name": "srcEndpoint=(For Each: EntityId), destEndpoint=(GetEntityName: EntityId)",
                                 "Components": {
@@ -7346,7 +7265,7 @@
                                         "Id": 9264970194993604803,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13536472857420
+                                                "id": 222950727077632
                                             },
                                             "slotId": {
                                                 "m_id": "{EFBD2747-E415-4B81-ACE6-774B50DCAD81}"
@@ -7354,7 +7273,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13579422530380
+                                                "id": 222937842175744
                                             },
                                             "slotId": {
                                                 "m_id": "{1346E4FE-F5E9-4397-86FF-6C2EE3ADBCCF}"
@@ -7365,7 +7284,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13815645731660
+                                    "id": 223169770409728
                                 },
                                 "Name": "srcEndpoint=(GetEntityName: Out), destEndpoint=(ScriptCanvas_StringFunctions_StartsWith: In)",
                                 "Components": {
@@ -7374,7 +7293,7 @@
                                         "Id": 17399331914319502412,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13579422530380
+                                                "id": 222937842175744
                                             },
                                             "slotId": {
                                                 "m_id": "{D2B5CFF9-69A7-42AF-AD2F-2F1E8C1B24F8}"
@@ -7382,7 +7301,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13497818151756
+                                                "id": 222959317012224
                                             },
                                             "slotId": {
                                                 "m_id": "{721060B9-5CB7-4F0F-8AC5-6E417DAB90EE}"
@@ -7393,7 +7312,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13819940698956
+                                    "id": 223174065377024
                                 },
                                 "Name": "srcEndpoint=(GetEntityName: String), destEndpoint=(ScriptCanvas_StringFunctions_StartsWith: Source)",
                                 "Components": {
@@ -7402,7 +7321,7 @@
                                         "Id": 678058827209620869,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13579422530380
+                                                "id": 222937842175744
                                             },
                                             "slotId": {
                                                 "m_id": "{AE9BDC35-285B-45E5-880B-E7AD8664CC40}"
@@ -7410,7 +7329,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13497818151756
+                                                "id": 222959317012224
                                             },
                                             "slotId": {
                                                 "m_id": "{EF99EF77-DDA5-422D-AAA6-5B3C641842BD}"
@@ -7421,7 +7340,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13824235666252
+                                    "id": 223178360344320
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_StringFunctions_StartsWith: True), destEndpoint=(ScriptCanvas_StringFunctions_EndsWith: In)",
                                 "Components": {
@@ -7430,7 +7349,7 @@
                                         "Id": 220927325398727367,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13497818151756
+                                                "id": 222959317012224
                                             },
                                             "slotId": {
                                                 "m_id": "{3D06B1F8-80C7-42E9-BEC0-C03B306255F6}"
@@ -7438,7 +7357,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13523587955532
+                                                "id": 222886302568192
                                             },
                                             "slotId": {
                                                 "m_id": "{4FA579D7-516F-4A97-8889-37843083E2BB}"
@@ -7449,7 +7368,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13828530633548
+                                    "id": 223182655311616
                                 },
                                 "Name": "srcEndpoint=(GetEntityName: String), destEndpoint=(ScriptCanvas_StringFunctions_EndsWith: Source)",
                                 "Components": {
@@ -7458,7 +7377,7 @@
                                         "Id": 8089147506964937985,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13579422530380
+                                                "id": 222937842175744
                                             },
                                             "slotId": {
                                                 "m_id": "{AE9BDC35-285B-45E5-880B-E7AD8664CC40}"
@@ -7466,7 +7385,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13523587955532
+                                                "id": 222886302568192
                                             },
                                             "slotId": {
                                                 "m_id": "{21E3453C-BCFA-4085-8384-70B7D0719A72}"
@@ -7477,7 +7396,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13832825600844
+                                    "id": 223186950278912
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_StringFunctions_EndsWith: True), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -7486,7 +7405,7 @@
                                         "Id": 12729500100384506558,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13523587955532
+                                                "id": 222886302568192
                                             },
                                             "slotId": {
                                                 "m_id": "{AB04A583-81B2-4F36-9E3B-76158EEFC78E}"
@@ -7494,7 +7413,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13549357759308
+                                                "id": 222997971717888
                                             },
                                             "slotId": {
                                                 "m_id": "{5829C658-C957-48AC-B5E9-7CB8C20F5A2F}"
@@ -7505,7 +7424,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13837120568140
+                                    "id": 223191245246208
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_StringFunctions_EndsWith: False), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -7514,7 +7433,7 @@
                                         "Id": 15146911510291621884,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13523587955532
+                                                "id": 222886302568192
                                             },
                                             "slotId": {
                                                 "m_id": "{A5BB0AFF-3CB0-406D-A471-63A851FEE747}"
@@ -7522,7 +7441,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13566537628492
+                                                "id": 222976496881408
                                             },
                                             "slotId": {
                                                 "m_id": "{A2057707-DC8F-4C14-9A04-FFD29D1EC5F0}"
@@ -7533,7 +7452,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13841415535436
+                                    "id": 223195540213504
                                 },
                                 "Name": "srcEndpoint=(For Each: EntityId), destEndpoint=(Set Variable: EntityId)",
                                 "Components": {
@@ -7542,7 +7461,7 @@
                                         "Id": 12408321598687450243,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13536472857420
+                                                "id": 222950727077632
                                             },
                                             "slotId": {
                                                 "m_id": "{EFBD2747-E415-4B81-ACE6-774B50DCAD81}"
@@ -7550,7 +7469,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13549357759308
+                                                "id": 222997971717888
                                             },
                                             "slotId": {
                                                 "m_id": "{23D4FFE2-E2D4-4CE5-B8B2-A5A755E954E3}"
@@ -7561,7 +7480,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 13845710502732
+                                    "id": 223199835180800
                                 },
                                 "Name": "srcEndpoint=(For Each: EntityId), destEndpoint=(Set Variable: EntityId)",
                                 "Components": {
@@ -7570,7 +7489,7 @@
                                         "Id": 6750137727981865398,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13536472857420
+                                                "id": 222950727077632
                                             },
                                             "slotId": {
                                                 "m_id": "{EFBD2747-E415-4B81-ACE6-774B50DCAD81}"
@@ -7578,7 +7497,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13566537628492
+                                                "id": 222976496881408
                                             },
                                             "slotId": {
                                                 "m_id": "{9FDA9496-FDA7-41E9-AC09-4ECBC4A5019B}"
@@ -7589,7 +7508,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 206633907518284
+                                    "id": 223204130148096
                                 },
                                 "Name": "srcEndpoint=(Set Variable: Out), destEndpoint=(SetVisibility: In)",
                                 "Components": {
@@ -7598,7 +7517,7 @@
                                         "Id": 581372407481735465,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13532177890124
+                                                "id": 222851942829824
                                             },
                                             "slotId": {
                                                 "m_id": "{774898E6-10FA-4EF5-9B6E-0E54842D873F}"
@@ -7606,7 +7525,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 205285287787340
+                                                "id": 222856237797120
                                             },
                                             "slotId": {
                                                 "m_id": "{F21A783E-454D-4C5C-9B6B-DAB1F445C709}"
@@ -7617,7 +7536,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 287924753529676
+                                    "id": 223208425115392
                                 },
                                 "Name": "srcEndpoint=(TimeDelay: Done), destEndpoint=(GetChildren: In)",
                                 "Components": {
@@ -7626,7 +7545,7 @@
                                         "Id": 6170254541658807069,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13643847039820
+                                                "id": 222882007600896
                                             },
                                             "slotId": {
                                                 "m_id": "{C0C2AE43-D89B-4040-9421-90D345467985}"
@@ -7634,7 +7553,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 245756764617548
+                                                "id": 222980791848704
                                             },
                                             "slotId": {
                                                 "m_id": "{6B47290C-3C65-43F3-B5BA-BE73F1845808}"
@@ -7645,7 +7564,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 304756730362700
+                                    "id": 223212720082688
                                 },
                                 "Name": "srcEndpoint=(GetChildren: Out), destEndpoint=(Get First Element: In)",
                                 "Components": {
@@ -7654,7 +7573,7 @@
                                         "Id": 13356749205701098652,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 245756764617548
+                                                "id": 222980791848704
                                             },
                                             "slotId": {
                                                 "m_id": "{18C1DF8F-48FD-480D-9364-D501C4AE7E1F}"
@@ -7662,7 +7581,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 303751708015436
+                                                "id": 222847647862528
                                             },
                                             "slotId": {
                                                 "m_id": "{E65053D3-7988-4126-A295-C398E0B8B03D}"
@@ -7673,7 +7592,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 305121802582860
+                                    "id": 223217015049984
                                 },
                                 "Name": "srcEndpoint=(GetChildren: Array<EntityId>), destEndpoint=(Get First Element: Container)",
                                 "Components": {
@@ -7682,7 +7601,7 @@
                                         "Id": 8481986846588711076,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 245756764617548
+                                                "id": 222980791848704
                                             },
                                             "slotId": {
                                                 "m_id": "{25B7839F-E43B-4C81-B565-DD0C30B44A65}"
@@ -7690,7 +7609,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 303751708015436
+                                                "id": 222847647862528
                                             },
                                             "slotId": {
                                                 "m_id": "{03EC9FCF-BDED-4759-8FEE-9CA2B7AF4CAD}"
@@ -7701,7 +7620,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 306955753618252
+                                    "id": 223221310017280
                                 },
                                 "Name": "srcEndpoint=(GetChildren: Out), destEndpoint=(Get First Element: In)",
                                 "Components": {
@@ -7710,7 +7629,7 @@
                                         "Id": 5089894360280842505,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 305830472186700
+                                                "id": 222912072371968
                                             },
                                             "slotId": {
                                                 "m_id": "{18C1DF8F-48FD-480D-9364-D501C4AE7E1F}"
@@ -7718,7 +7637,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 305826177219404
+                                                "id": 222873417666304
                                             },
                                             "slotId": {
                                                 "m_id": "{E65053D3-7988-4126-A295-C398E0B8B03D}"
@@ -7729,7 +7648,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 307028768062284
+                                    "id": 223225604984576
                                 },
                                 "Name": "srcEndpoint=(GetChildren: Array<EntityId>), destEndpoint=(Get First Element: Container)",
                                 "Components": {
@@ -7738,7 +7657,7 @@
                                         "Id": 17486366500766943732,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 305830472186700
+                                                "id": 222912072371968
                                             },
                                             "slotId": {
                                                 "m_id": "{25B7839F-E43B-4C81-B565-DD0C30B44A65}"
@@ -7746,7 +7665,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 305826177219404
+                                                "id": 222873417666304
                                             },
                                             "slotId": {
                                                 "m_id": "{03EC9FCF-BDED-4759-8FEE-9CA2B7AF4CAD}"
@@ -7757,7 +7676,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 308914258705228
+                                    "id": 223229899951872
                                 },
                                 "Name": "srcEndpoint=(Get First Element: Out), destEndpoint=(GetChildren: In)",
                                 "Components": {
@@ -7766,7 +7685,7 @@
                                         "Id": 3608991541950840410,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 303751708015436
+                                                "id": 222847647862528
                                             },
                                             "slotId": {
                                                 "m_id": "{4BCB4A14-109F-4313-86B6-45DAA0E59555}"
@@ -7774,7 +7693,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 305830472186700
+                                                "id": 222912072371968
                                             },
                                             "slotId": {
                                                 "m_id": "{6B47290C-3C65-43F3-B5BA-BE73F1845808}"
@@ -7785,7 +7704,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 309279330925388
+                                    "id": 223234194919168
                                 },
                                 "Name": "srcEndpoint=(Get First Element: Value), destEndpoint=(GetChildren: EntityId)",
                                 "Components": {
@@ -7794,7 +7713,7 @@
                                         "Id": 10416456065642429921,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 303751708015436
+                                                "id": 222847647862528
                                             },
                                             "slotId": {
                                                 "m_id": "{E3056CF4-5D03-46C4-87EE-D37B74E98284}"
@@ -7802,7 +7721,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 305830472186700
+                                                "id": 222912072371968
                                             },
                                             "slotId": {
                                                 "m_id": "{CEFE0879-54BC-476B-9815-A97966D1969B}"
@@ -7813,7 +7732,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 310245698566988
+                                    "id": 223238489886464
                                 },
                                 "Name": "srcEndpoint=(Get First Element: Out), destEndpoint=(GetEntityName: In)",
                                 "Components": {
@@ -7822,7 +7741,7 @@
                                         "Id": 2661408082910520785,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 305826177219404
+                                                "id": 222873417666304
                                             },
                                             "slotId": {
                                                 "m_id": "{4BCB4A14-109F-4313-86B6-45DAA0E59555}"
@@ -7830,7 +7749,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 248054572120908
+                                                "id": 222877712633600
                                             },
                                             "slotId": {
                                                 "m_id": "{61821EF3-1CA9-49A9-BC0D-8F91F2E0F6AC}"
@@ -7841,7 +7760,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 310524871441228
+                                    "id": 223242784853760
                                 },
                                 "Name": "srcEndpoint=(Get First Element: Value), destEndpoint=(GetEntityName: EntityId)",
                                 "Components": {
@@ -7850,7 +7769,7 @@
                                         "Id": 17930890867616511263,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 305826177219404
+                                                "id": 222873417666304
                                             },
                                             "slotId": {
                                                 "m_id": "{E3056CF4-5D03-46C4-87EE-D37B74E98284}"
@@ -7858,7 +7777,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 248054572120908
+                                                "id": 222877712633600
                                             },
                                             "slotId": {
                                                 "m_id": "{31FE371C-2170-451C-9B38-67089766514A}"
@@ -7869,7 +7788,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 370800442473292
+                                    "id": 223247079821056
                                 },
                                 "Name": "srcEndpoint=(Get First Element: Out), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -7878,7 +7797,7 @@
                                         "Id": 14517937506046073851,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 305826177219404
+                                                "id": 222873417666304
                                             },
                                             "slotId": {
                                                 "m_id": "{4BCB4A14-109F-4313-86B6-45DAA0E59555}"
@@ -7886,7 +7805,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 369696635878220
+                                                "id": 222843352895232
                                             },
                                             "slotId": {
                                                 "m_id": "{6D7DED17-45E9-449E-844F-C60385B6A9DC}"
@@ -7897,7 +7816,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 371066730445644
+                                    "id": 223251374788352
                                 },
                                 "Name": "srcEndpoint=(Get First Element: Value), destEndpoint=(Set Variable: EntityId)",
                                 "Components": {
@@ -7906,7 +7825,7 @@
                                         "Id": 5932670093517997066,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 305826177219404
+                                                "id": 222873417666304
                                             },
                                             "slotId": {
                                                 "m_id": "{E3056CF4-5D03-46C4-87EE-D37B74E98284}"
@@ -7914,7 +7833,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 369696635878220
+                                                "id": 222843352895232
                                             },
                                             "slotId": {
                                                 "m_id": "{FA8398CC-2F6E-42BC-B80C-599D9BC9583F}"
@@ -7925,7 +7844,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 410357091269452
+                                    "id": 223255669755648
                                 },
                                 "Name": "srcEndpoint=(SetVisibility: Out), destEndpoint=(SetVisibility: In)",
                                 "Components": {
@@ -7934,7 +7853,7 @@
                                         "Id": 14912612589509719141,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 402381337000780
+                                                "id": 222972201914112
                                             },
                                             "slotId": {
                                                 "m_id": "{4BC07C6A-F103-4DDE-B71E-0557673F6D7E}"
@@ -7942,7 +7861,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 403957589998412
+                                                "id": 222817583091456
                                             },
                                             "slotId": {
                                                 "m_id": "{2FB68547-E454-48ED-8369-380CF24A5046}"
@@ -7953,7 +7872,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 418083737434956
+                                    "id": 223259964722944
                                 },
                                 "Name": "srcEndpoint=(Set Variable: Out), destEndpoint=(ScriptCanvas_EntityFunctions_IsValid: In)",
                                 "Components": {
@@ -7962,7 +7881,7 @@
                                         "Id": 5141825410373125357,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13506408086348
+                                                "id": 222903482437376
                                             },
                                             "slotId": {
                                                 "m_id": "{CAC8E39C-068B-4750-9012-DAC55C42075A}"
@@ -7970,7 +7889,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 414682123336524
+                                                "id": 222890597535488
                                             },
                                             "slotId": {
                                                 "m_id": "{AECB7790-56B0-4062-BFA4-348459B12315}"
@@ -7981,7 +7900,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 418513234164556
+                                    "id": 223264259690240
                                 },
                                 "Name": "srcEndpoint=(ScriptCanvas_EntityFunctions_IsValid: Out), destEndpoint=(SetVisibility: In)",
                                 "Components": {
@@ -7990,7 +7909,7 @@
                                         "Id": 15883597979265398179,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 414682123336524
+                                                "id": 222890597535488
                                             },
                                             "slotId": {
                                                 "m_id": "{457A1FA0-65A6-4732-A191-2A4750220EF9}"
@@ -7998,7 +7917,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 402381337000780
+                                                "id": 222972201914112
                                             },
                                             "slotId": {
                                                 "m_id": "{2FB68547-E454-48ED-8369-380CF24A5046}"
@@ -8009,7 +7928,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 450171438103372
+                                    "id": 223268554657536
                                 },
                                 "Name": "srcEndpoint=(Set Variable: Out), destEndpoint=(SetVisibility: In)",
                                 "Components": {
@@ -8018,7 +7937,7 @@
                                         "Id": 304021833462513715,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13549357759308
+                                                "id": 222997971717888
                                             },
                                             "slotId": {
                                                 "m_id": "{0CBE12A8-A99A-41B4-B72F-05D1039E45E0}"
@@ -8026,7 +7945,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 446838543481676
+                                                "id": 222864827731712
                                             },
                                             "slotId": {
                                                 "m_id": "{D8103921-1B03-4F4B-B8EB-8047A3F3EE17}"
@@ -8037,7 +7956,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 464963305470796
+                                    "id": 223272849624832
                                 },
                                 "Name": "srcEndpoint=(Receive Script Event: ExecutionSlot:StartGame), destEndpoint=(SetVisibility: In)",
                                 "Components": {
@@ -8046,7 +7965,7 @@
                                         "Id": 2172958618735189737,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13596602399564
+                                                "id": 222899187470080
                                             },
                                             "slotId": {
                                                 "m_id": "{25BB124E-FA43-4A9C-8A39-0A8DB4C91552}"
@@ -8054,7 +7973,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 461531626601292
+                                                "id": 222989381783296
                                             },
                                             "slotId": {
                                                 "m_id": "{E8A41188-3559-4EF3-9AA5-BC15D4EFEC03}"
@@ -8065,7 +7984,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 465268248148812
+                                    "id": 223277144592128
                                 },
                                 "Name": "srcEndpoint=(SetVisibility: Out), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -8074,7 +7993,7 @@
                                         "Id": 855028764293035458,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 461531626601292
+                                                "id": 222989381783296
                                             },
                                             "slotId": {
                                                 "m_id": "{76F4EC21-F5D2-4E2C-9155-2DB4BABA55B3}"
@@ -8082,7 +8001,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13480638282572
+                                                "id": 222924957273856
                                             },
                                             "slotId": {
                                                 "m_id": "{298D5B1E-F022-4432-83D1-0C6F92855595}"
@@ -8093,7 +8012,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 476035731159884
+                                    "id": 223281439559424
                                 },
                                 "Name": "srcEndpoint=(If: True), destEndpoint=(SetVisibility: In)",
                                 "Components": {
@@ -8102,7 +8021,7 @@
                                         "Id": 14000336369025202442,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13600897366860
+                                                "id": 222946432110336
                                             },
                                             "slotId": {
                                                 "m_id": "{18199EB6-157A-4765-A3AB-0F669DEB1BA8}"
@@ -8110,7 +8029,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 469945467534156
+                                                "id": 222955022044928
                                             },
                                             "slotId": {
                                                 "m_id": "{E8A41188-3559-4EF3-9AA5-BC15D4EFEC03}"
@@ -8121,7 +8040,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 477242616970060
+                                    "id": 223285734526720
                                 },
                                 "Name": "srcEndpoint=(SetVisibility: Out), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -8130,7 +8049,7 @@
                                         "Id": 14876980734198628447,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 469945467534156
+                                                "id": 222955022044928
                                             },
                                             "slotId": {
                                                 "m_id": "{76F4EC21-F5D2-4E2C-9155-2DB4BABA55B3}"
@@ -8138,7 +8057,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13557947693900
+                                                "id": 223002266685184
                                             },
                                             "slotId": {
                                                 "m_id": "{960FA55C-59FE-4562-BABA-29E09260DAFC}"
@@ -8149,7 +8068,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 487735222074188
+                                    "id": 223290029494016
                                 },
                                 "Name": "srcEndpoint=(If: False), destEndpoint=(SetVisibility: In)",
                                 "Components": {
@@ -8158,7 +8077,7 @@
                                         "Id": 12552352065757301553,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 13600897366860
+                                                "id": 222946432110336
                                             },
                                             "slotId": {
                                                 "m_id": "{BA4F221D-464A-44F4-9154-C70F62B6E1A1}"
@@ -8166,7 +8085,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 479622028852044
+                                                "id": 222920662306560
                                             },
                                             "slotId": {
                                                 "m_id": "{E8A41188-3559-4EF3-9AA5-BC15D4EFEC03}"
@@ -8177,7 +8096,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 491557742967628
+                                    "id": 223294324461312
                                 },
                                 "Name": "srcEndpoint=(SetVisibility: Out), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -8186,7 +8105,7 @@
                                         "Id": 12987942745203980115,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 479622028852044
+                                                "id": 222920662306560
                                             },
                                             "slotId": {
                                                 "m_id": "{76F4EC21-F5D2-4E2C-9155-2DB4BABA55B3}"
@@ -8194,10 +8113,150 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 13506408086348
+                                                "id": 222903482437376
                                             },
                                             "slotId": {
                                                 "m_id": "{5C87BB50-F4D4-483B-9487-BFF1914571E9}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 522546170810112
+                                },
+                                "Name": "srcEndpoint=(On Trigger Enter event: OnEvent), destEndpoint=(GetOtherEntityId: In)",
+                                "Components": {
+                                    "Component_[2689691454457645710]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 2689691454457645710,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 222860532764416
+                                            },
+                                            "slotId": {
+                                                "m_id": "{B7D21051-E978-4A0B-ADF8-A69E865FFF9D}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 514901129023232
+                                            },
+                                            "slotId": {
+                                                "m_id": "{29589F1A-BA42-44A5-B191-A6163C9A1E39}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 525913425170176
+                                },
+                                "Name": "srcEndpoint=(On Trigger Enter event: Trigger Event), destEndpoint=(GetOtherEntityId: TriggerEvent)",
+                                "Components": {
+                                    "Component_[10942464686942480883]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 10942464686942480883,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 222860532764416
+                                            },
+                                            "slotId": {
+                                                "m_id": "{81922A76-4BFE-4EB4-8929-28DE937AAB21}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 514901129023232
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A96105BA-25E3-4362-B46C-0A517B8D9CB0}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 528752398552832
+                                },
+                                "Name": "srcEndpoint=(GetOtherEntityId: Out), destEndpoint=(GetEntityName: In)",
+                                "Components": {
+                                    "Component_[8470624502756913005]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 8470624502756913005,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 514901129023232
+                                            },
+                                            "slotId": {
+                                                "m_id": "{E1249F98-FB16-4D6C-AA6E-583CADE512A5}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 222933547208448
+                                            },
+                                            "slotId": {
+                                                "m_id": "{986A3CC3-3C87-41F7-A00C-55587DABB350}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 530350126386944
+                                },
+                                "Name": "srcEndpoint=(GetOtherEntityId: EntityId), destEndpoint=(GetEntityName: EntityId)",
+                                "Components": {
+                                    "Component_[7620267734156146816]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 7620267734156146816,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 514901129023232
+                                            },
+                                            "slotId": {
+                                                "m_id": "{BC183546-38BB-44C9-83C9-9C963A24C2D6}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 222933547208448
+                                            },
+                                            "slotId": {
+                                                "m_id": "{1127602F-F67C-4C0E-9988-C349650276A3}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 531909199515392
+                                },
+                                "Name": "srcEndpoint=(GetOtherEntityId: EntityId), destEndpoint=(DeactivateGameEntity: EntityId)",
+                                "Components": {
+                                    "Component_[16810629309759196260]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 16810629309759196260,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 514901129023232
+                                            },
+                                            "slotId": {
+                                                "m_id": "{BC183546-38BB-44C9-83C9-9C963A24C2D6}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 222894892502784
+                                            },
+                                            "slotId": {
+                                                "m_id": "{84E620D8-3AC5-4077-9A05-DAB66CFB421B}"
                                             }
                                         }
                                     }
@@ -8207,55 +8266,55 @@
                         "m_scriptEventAssets": [
                             [
                                 {
-                                    "id": 13570832595788
+                                    "id": 222808993156864
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 13570832595788
+                                    "id": 222808993156864
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 13570832595788
+                                    "id": 222808993156864
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 13570832595788
+                                    "id": 222808993156864
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 13570832595788
+                                    "id": 222808993156864
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 13570832595788
+                                    "id": 222808993156864
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 13596602399564
+                                    "id": 222899187470080
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 13570832595788
+                                    "id": 222808993156864
                                 },
                                 {}
                             ],
                             [
                                 {
-                                    "id": 13489228217164
+                                    "id": 222967906946816
                                 },
                                 {}
                             ]
@@ -8271,122 +8330,13 @@
                     "GraphCanvasData": [
                         {
                             "Key": {
-                                "id": 13467753380684
+                                "id": 222804698189568
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
                                         "$type": "SceneComponentSaveData",
                                         "Constructs": [
-                                            {
-                                                "Type": 3,
-                                                "DataContainer": {
-                                                    "ComponentData": {
-                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                                            "$type": "NodeSaveData"
-                                                        },
-                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
-                                                            "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "Check if our target was hit by a Newspaper",
-                                                            "BackgroundColor": [
-                                                                0.8659999966621399,
-                                                                0.49799999594688416,
-                                                                0.4269999861717224
-                                                            ],
-                                                            "FontSettings": {
-                                                                "PixelSize": 16
-                                                            }
-                                                        },
-                                                        "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
-                                                            "$type": "NodeGroupFrameComponentSaveData",
-                                                            "DisplayHeight": 400.0,
-                                                            "DisplayWidth": 2660.0,
-                                                            "PersistentGroupedId": [
-                                                                "{F833D979-B524-4127-9B70-8930170E012D}",
-                                                                "{866BBA00-3EDB-4FCD-865B-2E466751C415}",
-                                                                "{8F6A4CD8-689F-4D22-946F-AF655FA33492}",
-                                                                "{42B01AEA-1DDD-4C38-A1CB-7CC9E02214D2}",
-                                                                "{546E19FE-E008-4F11-8869-9F7493B82927}",
-                                                                "{B66A6B5C-0497-4E63-BED8-5A256D26A851}"
-                                                            ]
-                                                        },
-                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                                            "$type": "GeometrySaveData",
-                                                            "Position": [
-                                                                300.0,
-                                                                200.0
-                                                            ]
-                                                        },
-                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                                            "$type": "StylingComponentSaveData"
-                                                        },
-                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                                            "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{DE64B115-EC5F-4434-9C97-C4CD16B75CB5}"
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                "Type": 3,
-                                                "DataContainer": {
-                                                    "ComponentData": {
-                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                                            "$type": "NodeSaveData"
-                                                        },
-                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
-                                                            "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "Find the regular and dark house entities and hide the dark one by default",
-                                                            "BackgroundColor": [
-                                                                0.9800000190734863,
-                                                                0.9700000286102295,
-                                                                0.6499999761581421
-                                                            ],
-                                                            "FontSettings": {
-                                                                "PixelSize": 16
-                                                            }
-                                                        },
-                                                        "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
-                                                            "$type": "NodeGroupFrameComponentSaveData",
-                                                            "DisplayHeight": 680.0,
-                                                            "DisplayWidth": 4160.0,
-                                                            "PersistentGroupedId": [
-                                                                "{CFBFAA16-95D3-41A5-9E31-39B53BD261A8}",
-                                                                "{8F24FA31-CDA9-4010-A5F5-674BB9052106}",
-                                                                "{945639EC-6042-4424-B68D-8761ADECF28A}",
-                                                                "{BA5248C4-A138-41F9-B0C9-103713AF9651}",
-                                                                "{A76CE5DE-2FDA-428C-9260-5D333C692F9F}",
-                                                                "{586C7625-C9A4-4D2D-9AD9-ADBB1092DB1B}",
-                                                                "{2D317332-F782-4B11-BFC6-E0CE5A8D9A31}",
-                                                                "{42D92C9C-AE51-4006-B2F0-72FCE4D572A7}",
-                                                                "{96445FFE-AF71-4506-8A22-625804533974}",
-                                                                "{37EDF302-786C-4243-8E32-E733CFC0D8B1}",
-                                                                "{838A9277-AEEA-4166-97C7-86F4F94A9848}",
-                                                                "{EF01FCC5-A4AE-4441-BB37-D043A27BAFDC}",
-                                                                "{2276D5FC-17AC-4F9F-93F5-626FFE5B858A}",
-                                                                "{B1E1F2A9-B6B8-4ED5-AB51-C6C815ACD7F9}",
-                                                                "{293D1EE4-16AA-427D-BE5C-EE5E37AB38A7}",
-                                                                "{F315EFD0-1C8D-4CA5-8CB3-13350F5D374D}",
-                                                                "{49D34BAE-1EF6-403C-B9CF-202D2CD09A35}"
-                                                            ]
-                                                        },
-                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                                            "$type": "GeometrySaveData",
-                                                            "Position": [
-                                                                520.0,
-                                                                -640.0
-                                                            ]
-                                                        },
-                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                                            "$type": "StylingComponentSaveData"
-                                                        },
-                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                                            "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{FDBE1A08-8B8E-41D1-8037-AEB1A74B04EC}"
-                                                        }
-                                                    }
-                                                }
-                                            },
                                             {
                                                 "Type": 3,
                                                 "DataContainer": {
@@ -8429,6 +8379,104 @@
                                                         "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                                             "$type": "PersistentIdComponentSaveData",
                                                             "PersistentId": "{1D9516B6-0A86-429B-B133-AFFF6C9DE25D}"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "Type": 3,
+                                                "DataContainer": {
+                                                    "ComponentData": {
+                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                                            "$type": "NodeSaveData"
+                                                        },
+                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
+                                                            "$type": "CommentNodeTextSaveData",
+                                                            "Comment": "The NewspaperTarget containers name will be something like \"NewspaperTarget_1337\" where the suffix will be how many points this target is worth. So split the name by \"_\" so we can trigger the script event for points scored",
+                                                            "BackgroundColor": [
+                                                                0.9800000190734863,
+                                                                0.9700000286102295,
+                                                                0.6499999761581421
+                                                            ],
+                                                            "FontSettings": {
+                                                                "PixelSize": 16
+                                                            }
+                                                        },
+                                                        "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
+                                                            "$type": "NodeGroupFrameComponentSaveData",
+                                                            "DisplayHeight": 287.0,
+                                                            "DisplayWidth": 2520.0,
+                                                            "PersistentGroupedId": [
+                                                                "{F2211FC7-02A8-4053-8DC6-895873937371}",
+                                                                "{52EE530C-A0AC-4CC8-827C-910D70BA0EAC}",
+                                                                "{6AB20A9C-1848-4337-A271-1A720BF7D5B5}",
+                                                                "{D4A2319C-45AB-4914-BE23-2A42391E4C51}",
+                                                                "{A59C517E-A87E-47B5-BE6D-B10A49A9E695}",
+                                                                "{62CC36DC-2A9B-43AB-980F-974256D03687}"
+                                                            ]
+                                                        },
+                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                                            "$type": "GeometrySaveData",
+                                                            "Position": [
+                                                                3940.0,
+                                                                460.0
+                                                            ]
+                                                        },
+                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                                            "$type": "StylingComponentSaveData"
+                                                        },
+                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                                            "$type": "PersistentIdComponentSaveData",
+                                                            "PersistentId": "{A5A44646-6FF0-445B-A453-332D4D1A4735}"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "Type": 3,
+                                                "DataContainer": {
+                                                    "ComponentData": {
+                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                                            "$type": "NodeSaveData"
+                                                        },
+                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
+                                                            "$type": "CommentNodeTextSaveData",
+                                                            "Comment": "Check if our target was hit by a Newspaper",
+                                                            "BackgroundColor": [
+                                                                0.8659999966621399,
+                                                                0.49799999594688416,
+                                                                0.4269999861717224
+                                                            ],
+                                                            "FontSettings": {
+                                                                "PixelSize": 16
+                                                            }
+                                                        },
+                                                        "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
+                                                            "$type": "NodeGroupFrameComponentSaveData",
+                                                            "DisplayHeight": 400.0,
+                                                            "DisplayWidth": 2660.0,
+                                                            "PersistentGroupedId": [
+                                                                "{90CF22A6-9711-4305-8E3C-C0E0A061EAF4}",
+                                                                "{B66A6B5C-0497-4E63-BED8-5A256D26A851}",
+                                                                "{F833D979-B524-4127-9B70-8930170E012D}",
+                                                                "{866BBA00-3EDB-4FCD-865B-2E466751C415}",
+                                                                "{42B01AEA-1DDD-4C38-A1CB-7CC9E02214D2}",
+                                                                "{546E19FE-E008-4F11-8869-9F7493B82927}"
+                                                            ]
+                                                        },
+                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                                            "$type": "GeometrySaveData",
+                                                            "Position": [
+                                                                300.0,
+                                                                200.0
+                                                            ]
+                                                        },
+                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                                            "$type": "StylingComponentSaveData"
+                                                        },
+                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                                            "$type": "PersistentIdComponentSaveData",
+                                                            "PersistentId": "{DE64B115-EC5F-4434-9C97-C4CD16B75CB5}"
                                                         }
                                                     }
                                                 }
@@ -8494,7 +8542,7 @@
                                                         },
                                                         "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
                                                             "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "The NewspaperTarget containers name will be something like \"NewspaperTarget_1337\" where the suffix will be how many points this target is worth. So split the name by \"_\" so we can trigger the script event for points scored",
+                                                            "Comment": "Find the regular and dark house entities and hide the dark one by default",
                                                             "BackgroundColor": [
                                                                 0.9800000190734863,
                                                                 0.9700000286102295,
@@ -8506,22 +8554,33 @@
                                                         },
                                                         "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
                                                             "$type": "NodeGroupFrameComponentSaveData",
-                                                            "DisplayHeight": 287.0,
-                                                            "DisplayWidth": 2520.0,
+                                                            "DisplayHeight": 680.0,
+                                                            "DisplayWidth": 4160.0,
                                                             "PersistentGroupedId": [
-                                                                "{F2211FC7-02A8-4053-8DC6-895873937371}",
-                                                                "{52EE530C-A0AC-4CC8-827C-910D70BA0EAC}",
-                                                                "{6AB20A9C-1848-4337-A271-1A720BF7D5B5}",
-                                                                "{D4A2319C-45AB-4914-BE23-2A42391E4C51}",
-                                                                "{A59C517E-A87E-47B5-BE6D-B10A49A9E695}",
-                                                                "{62CC36DC-2A9B-43AB-980F-974256D03687}"
+                                                                "{CFBFAA16-95D3-41A5-9E31-39B53BD261A8}",
+                                                                "{8F24FA31-CDA9-4010-A5F5-674BB9052106}",
+                                                                "{945639EC-6042-4424-B68D-8761ADECF28A}",
+                                                                "{BA5248C4-A138-41F9-B0C9-103713AF9651}",
+                                                                "{A76CE5DE-2FDA-428C-9260-5D333C692F9F}",
+                                                                "{586C7625-C9A4-4D2D-9AD9-ADBB1092DB1B}",
+                                                                "{2D317332-F782-4B11-BFC6-E0CE5A8D9A31}",
+                                                                "{42D92C9C-AE51-4006-B2F0-72FCE4D572A7}",
+                                                                "{96445FFE-AF71-4506-8A22-625804533974}",
+                                                                "{37EDF302-786C-4243-8E32-E733CFC0D8B1}",
+                                                                "{838A9277-AEEA-4166-97C7-86F4F94A9848}",
+                                                                "{EF01FCC5-A4AE-4441-BB37-D043A27BAFDC}",
+                                                                "{2276D5FC-17AC-4F9F-93F5-626FFE5B858A}",
+                                                                "{B1E1F2A9-B6B8-4ED5-AB51-C6C815ACD7F9}",
+                                                                "{293D1EE4-16AA-427D-BE5C-EE5E37AB38A7}",
+                                                                "{F315EFD0-1C8D-4CA5-8CB3-13350F5D374D}",
+                                                                "{49D34BAE-1EF6-403C-B9CF-202D2CD09A35}"
                                                             ]
                                                         },
                                                         "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                                             "$type": "GeometrySaveData",
                                                             "Position": [
-                                                                3940.0,
-                                                                460.0
+                                                                520.0,
+                                                                -640.0
                                                             ]
                                                         },
                                                         "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -8529,16 +8588,16 @@
                                                         },
                                                         "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                                             "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{A5A44646-6FF0-445B-A453-332D4D1A4735}"
+                                                            "PersistentId": "{FDBE1A08-8B8E-41D1-8037-AEB1A74B04EC}"
                                                         }
                                                     }
                                                 }
                                             }
                                         ],
                                         "ViewParams": {
-                                            "Scale": 0.36236311504143326,
-                                            "AnchorX": 237.33099365234375,
-                                            "AnchorY": -1123.1827392578125
+                                            "Scale": 0.45202108291212384,
+                                            "AnchorX": 657.0490112304688,
+                                            "AnchorY": -214.59176635742188
                                         }
                                     }
                                 }
@@ -8546,7 +8605,38 @@
                         },
                         {
                             "Key": {
-                                "id": 13472048347980
+                                "id": 222808993156864
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            6160.0,
+                                            520.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{D4A2319C-45AB-4914-BE23-2A42391E4C51}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222813288124160
                             },
                             "Value": {
                                 "ComponentData": {
@@ -8580,7 +8670,7 @@
                         },
                         {
                             "Key": {
-                                "id": 13476343315276
+                                "id": 222817583091456
                             },
                             "Value": {
                                 "ComponentData": {
@@ -8594,216 +8684,24 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            960.0,
-                                            -540.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{37EDF302-786C-4243-8E32-E733CFC0D8B1}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13480638282572
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "SetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1460.0,
-                                            780.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".setVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{68950858-0096-4F1E-8750-5E4267E42DD3}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13489228217164
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            180.0,
-                                            1240.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{DD5A26C2-78B3-4F6D-A596-8FD516869DB2}"
-                                    },
-                                    "{D8BBE799-7E4D-495A-B69A-1E3940670891}": {
-                                        "$type": "ScriptEventReceiverHandlerNodeDescriptorSaveData",
-                                        "EventNames": [
-                                            [
-                                                {
-                                                    "Value": 3075378332
-                                                },
-                                                "NextLevel"
-                                            ]
-                                        ]
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13493523184460
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1420.0,
-                                            -540.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{586C7625-C9A4-4D2D-9AD9-ADBB1092DB1B}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13497818151756
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3180.0,
-                                            -540.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{293D1EE4-16AA-427D-BE5C-EE5E37AB38A7}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13502113119052
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2640.0,
-                                            440.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F833D979-B524-4127-9B70-8930170E012D}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13506408086348
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "SetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1780.0,
+                                            2920.0,
                                             1480.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
                                         "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".setVariable"
+                                        "SubStyle": ".method"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{1975922D-8F96-4FF4-B029-81A50910C362}"
+                                        "PersistentId": "{032F5B78-D5CE-4950-A897-87D475BA7B5A}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 13510703053644
+                                "id": 222821878058752
                             },
                             "Value": {
                                 "ComponentData": {
@@ -8817,7 +8715,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            5700.0,
+                                            3960.0,
                                             520.0
                                         ]
                                     },
@@ -8827,14 +8725,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F2211FC7-02A8-4053-8DC6-895873937371}"
+                                        "PersistentId": "{A59C517E-A87E-47B5-BE6D-B10A49A9E695}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 13514998020940
+                                "id": 222826173026048
                             },
                             "Value": {
                                 "ComponentData": {
@@ -8843,137 +8741,13 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                        "PaletteOverride": "LogicNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            4440.0,
-                                            520.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{62CC36DC-2A9B-43AB-980F-974256D03687}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13519292988236
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            320.0,
-                                            260.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{42B01AEA-1DDD-4C38-A1CB-7CC9E02214D2}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13523587955532
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3520.0,
-                                            -500.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{A76CE5DE-2FDA-428C-9260-5D333C692F9F}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13532177890124
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "SetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            6500.0,
-                                            520.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".setVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{37470F69-4CBE-4388-8F73-C3A838E9336D}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13536472857420
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "DefaultNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2380.0,
-                                            -540.0
+                                            3380.0,
+                                            440.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -8981,76 +8755,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{945639EC-6042-4424-B68D-8761ADECF28A}"
+                                        "PersistentId": "{1E1EDD45-2C89-4BB9-8CDC-18941E81CF70}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 13545062792012
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            4900.0,
-                                            520.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{6AB20A9C-1848-4337-A271-1A720BF7D5B5}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13549357759308
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "SetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3880.0,
-                                            -500.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".setVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{EF01FCC5-A4AE-4441-BB37-D043A27BAFDC}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13553652726604
+                                "id": 222830467993344
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9081,69 +8793,7 @@
                         },
                         {
                             "Key": {
-                                "id": 13557947693900
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "SetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1780.0,
-                                            1220.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".setVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{D7FB9328-EF14-4184-ABFD-DB84664AA0E4}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13566537628492
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "SetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3880.0,
-                                            -320.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".setVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{2276D5FC-17AC-4F9F-93F5-626FFE5B858A}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13570832595788
+                                "id": 222834762960640
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9157,8 +8807,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            6160.0,
-                                            520.0
+                                            320.0,
+                                            260.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -9167,45 +8817,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{D4A2319C-45AB-4914-BE23-2A42391E4C51}"
+                                        "PersistentId": "{42B01AEA-1DDD-4C38-A1CB-7CC9E02214D2}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 13579422530380
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2700.0,
-                                            -540.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{42D92C9C-AE51-4006-B2F0-72FCE4D572A7}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13583717497676
+                                "id": 222839057927936
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9236,7 +8855,409 @@
                         },
                         {
                             "Key": {
-                                "id": 13596602399564
+                                "id": 222843352895232
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2500.0,
+                                            -120.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".setVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{49D34BAE-1EF6-403C-B9CF-202D2CD09A35}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222847647862528
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1380.0,
+                                            -280.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{8F24FA31-CDA9-4010-A5F5-674BB9052106}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222851942829824
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            6500.0,
+                                            520.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".setVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{37470F69-4CBE-4388-8F73-C3A838E9336D}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222856237797120
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            6840.0,
+                                            520.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{09D4DFAC-CECA-48C5-AD21-F40182C0B7D0}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222860532764416
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "HandlerNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            920.0,
+                                            260.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".azeventhandler"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{B66A6B5C-0497-4E63-BED8-5A256D26A851}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222864827731712
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            4360.0,
+                                            -500.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{2D317332-F782-4B11-BFC6-E0CE5A8D9A31}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222869122699008
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            4900.0,
+                                            520.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{6AB20A9C-1848-4337-A271-1A720BF7D5B5}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222873417666304
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2160.0,
+                                            -280.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{BA5248C4-A138-41F9-B0C9-103713AF9651}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222877712633600
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2480.0,
+                                            -280.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{F315EFD0-1C8D-4CA5-8CB3-13350F5D374D}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222882007600896
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "TimeNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            540.0,
+                                            -580.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{B1E1F2A9-B6B8-4ED5-AB51-C6C815ACD7F9}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222886302568192
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            3520.0,
+                                            -500.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{A76CE5DE-2FDA-428C-9260-5D333C692F9F}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222890597535488
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2100.0,
+                                            1480.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{F9EA5936-FEFA-4B04-AA37-9D7837F151A3}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222894892502784
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2640.0,
+                                            440.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{F833D979-B524-4127-9B70-8930170E012D}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222899187470080
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9273,7 +9294,7 @@
                         },
                         {
                             "Key": {
-                                "id": 13600897366860
+                                "id": 222903482437376
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9282,119 +9303,29 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "LogicNodeTitlePalette"
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            680.0,
-                                            1280.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{B79DE07D-ABBF-4515-96F6-1114DBECF5C1}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13605192334156
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "LogicNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3040.0,
-                                            440.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{D632ABF8-C956-4E97-9937-3AACC1FCBEE6}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13609487301452
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "LogicNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3380.0,
-                                            440.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{1E1EDD45-2C89-4BB9-8CDC-18941E81CF70}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13618077236044
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "HandlerNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            920.0,
-                                            260.0
+                                            1780.0,
+                                            1480.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
                                         "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".azeventhandler"
+                                        "SubStyle": ".setVariable"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{B66A6B5C-0497-4E63-BED8-5A256D26A851}"
+                                        "PersistentId": "{1975922D-8F96-4FF4-B029-81A50910C362}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 13622372203340
+                                "id": 222907777404672
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9408,69 +9339,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1400.0,
-                                            340.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{8F6A4CD8-689F-4D22-946F-AF655FA33492}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13626667170636
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2220.0,
-                                            340.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{866BBA00-3EDB-4FCD-865B-2E466751C415}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13630962137932
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3960.0,
+                                            4440.0,
                                             520.0
                                         ]
                                     },
@@ -9480,230 +9349,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{A59C517E-A87E-47B5-BE6D-B10A49A9E695}"
+                                        "PersistentId": "{62CC36DC-2A9B-43AB-980F-974256D03687}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 13635257105228
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1740.0,
-                                            340.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{546E19FE-E008-4F11-8869-9F7493B82927}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 13643847039820
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "TimeNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            540.0,
-                                            -580.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{B1E1F2A9-B6B8-4ED5-AB51-C6C815ACD7F9}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 205285287787340
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            6840.0,
-                                            520.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{09D4DFAC-CECA-48C5-AD21-F40182C0B7D0}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 245756764617548
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            920.0,
-                                            -280.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{CFBFAA16-95D3-41A5-9E31-39B53BD261A8}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 248054572120908
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2480.0,
-                                            -280.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F315EFD0-1C8D-4CA5-8CB3-13350F5D374D}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 303751708015436
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1380.0,
-                                            -280.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{8F24FA31-CDA9-4010-A5F5-674BB9052106}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 305826177219404
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2160.0,
-                                            -280.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{BA5248C4-A138-41F9-B0C9-103713AF9651}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 305830472186700
+                                "id": 222912072371968
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9734,7 +9387,69 @@
                         },
                         {
                             "Key": {
-                                "id": 369696635878220
+                                "id": 222916367339264
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1420.0,
+                                            -540.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{586C7625-C9A4-4D2D-9AD9-ADBB1092DB1B}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222920662306560
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1200.0,
+                                            1480.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{8EA04FFA-9DD4-4820-AFF7-6A280642E77C}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222924957273856
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9748,8 +9463,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            2500.0,
-                                            -120.0
+                                            1460.0,
+                                            780.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -9758,14 +9473,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{49D34BAE-1EF6-403C-B9CF-202D2CD09A35}"
+                                        "PersistentId": "{68950858-0096-4F1E-8750-5E4267E42DD3}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 402381337000780
+                                "id": 222929252241152
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9779,8 +9494,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            2580.0,
-                                            1480.0
+                                            2220.0,
+                                            340.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -9789,14 +9504,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{CA725EE2-E891-4B62-B61D-1D3E2FA05B7D}"
+                                        "PersistentId": "{866BBA00-3EDB-4FCD-865B-2E466751C415}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 403957589998412
+                                "id": 222933547208448
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9810,8 +9525,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            2920.0,
-                                            1480.0
+                                            1740.0,
+                                            340.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -9820,14 +9535,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{032F5B78-D5CE-4950-A897-87D475BA7B5A}"
+                                        "PersistentId": "{546E19FE-E008-4F11-8869-9F7493B82927}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 414682123336524
+                                "id": 222937842175744
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9841,8 +9556,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            2100.0,
-                                            1480.0
+                                            2700.0,
+                                            -540.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -9851,14 +9566,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F9EA5936-FEFA-4B04-AA37-9D7837F151A3}"
+                                        "PersistentId": "{42D92C9C-AE51-4006-B2F0-72FCE4D572A7}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 446838543481676
+                                "id": 222942137143040
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9867,29 +9582,28 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                        "PaletteOverride": "LogicNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            4360.0,
-                                            -500.0
+                                            3040.0,
+                                            440.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
+                                        "$type": "StylingComponentSaveData"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{2D317332-F782-4B11-BFC6-E0CE5A8D9A31}"
+                                        "PersistentId": "{D632ABF8-C956-4E97-9937-3AACC1FCBEE6}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 461531626601292
+                                "id": 222946432110336
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9898,29 +9612,58 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                        "PaletteOverride": "LogicNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            940.0,
-                                            780.0
+                                            680.0,
+                                            1280.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
+                                        "$type": "StylingComponentSaveData"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{D0AE6E98-DB84-40CA-B241-FCC1E5BCE3AF}"
+                                        "PersistentId": "{B79DE07D-ABBF-4515-96F6-1114DBECF5C1}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 469945467534156
+                                "id": 222950727077632
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2380.0,
+                                            -540.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{945639EC-6042-4424-B68D-8761ADECF28A}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222955022044928
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9951,7 +9694,7 @@
                         },
                         {
                             "Key": {
-                                "id": 479622028852044
+                                "id": 222959317012224
                             },
                             "Value": {
                                 "ComponentData": {
@@ -9965,7 +9708,106 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1200.0,
+                                            3180.0,
+                                            -540.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{293D1EE4-16AA-427D-BE5C-EE5E37AB38A7}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222963611979520
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            5700.0,
+                                            520.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{F2211FC7-02A8-4053-8DC6-895873937371}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222967906946816
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            180.0,
+                                            1240.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{DD5A26C2-78B3-4F6D-A596-8FD516869DB2}"
+                                    },
+                                    "{D8BBE799-7E4D-495A-B69A-1E3940670891}": {
+                                        "$type": "ScriptEventReceiverHandlerNodeDescriptorSaveData",
+                                        "EventNames": [
+                                            [
+                                                {
+                                                    "Value": 3075378332
+                                                },
+                                                "NextLevel"
+                                            ]
+                                        ]
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222972201914112
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2580.0,
                                             1480.0
                                         ]
                                     },
@@ -9975,7 +9817,224 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{8EA04FFA-9DD4-4820-AFF7-6A280642E77C}"
+                                        "PersistentId": "{CA725EE2-E891-4B62-B61D-1D3E2FA05B7D}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222976496881408
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            3880.0,
+                                            -320.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".setVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{2276D5FC-17AC-4F9F-93F5-626FFE5B858A}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222980791848704
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            920.0,
+                                            -280.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{CFBFAA16-95D3-41A5-9E31-39B53BD261A8}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222985086816000
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            960.0,
+                                            -540.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{37EDF302-786C-4243-8E32-E733CFC0D8B1}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222989381783296
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            940.0,
+                                            780.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{D0AE6E98-DB84-40CA-B241-FCC1E5BCE3AF}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 222997971717888
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            3880.0,
+                                            -500.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".setVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{EF01FCC5-A4AE-4441-BB37-D043A27BAFDC}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 223002266685184
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1780.0,
+                                            1220.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".setVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{D7FB9328-EF14-4184-ABFD-DB84664AA0E4}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 514901129023232
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1400.0,
+                                            320.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{90CF22A6-9711-4305-8E3C-C0E0A061EAF4}"
                                     }
                                 }
                             }
@@ -9983,6 +10042,10 @@
                     ],
                     "StatisticsHelper": {
                         "InstanceCounter": [
+                            {
+                                "Key": 1014541492674260157,
+                                "Value": 1
+                            },
                             {
                                 "Key": 1678857419506638996,
                                 "Value": 1
@@ -10029,10 +10092,6 @@
                             },
                             {
                                 "Key": 6690812097389395639,
-                                "Value": 1
-                            },
-                            {
-                                "Key": 8297829146692766414,
                                 "Value": 1
                             },
                             {
@@ -10109,6 +10168,7 @@
                                 },
                                 "Value": {
                                     "Datum": {
+                                        "isOverloadedStorage": false,
                                         "scriptCanvasType": {
                                             "m_type": 0
                                         },
@@ -10128,6 +10188,7 @@
                                 },
                                 "Value": {
                                     "Datum": {
+                                        "isOverloadedStorage": false,
                                         "scriptCanvasType": {
                                             "m_type": 1
                                         },
@@ -10149,6 +10210,7 @@
                                 },
                                 "Value": {
                                     "Datum": {
+                                        "isOverloadedStorage": false,
                                         "scriptCanvasType": {
                                             "m_type": 0
                                         },
@@ -10168,6 +10230,7 @@
                                 },
                                 "Value": {
                                     "Datum": {
+                                        "isOverloadedStorage": false,
                                         "scriptCanvasType": {
                                             "m_type": 1
                                         },


### PR DESCRIPTION
Fixed #11 

Fixed outdated Script Canvas node references in the `Car` and `NewspaperTarget` scripts.

Tested and verified the functionality for those scripts still works as expected.

Signed-off-by: Chris Galvan <chgalvan@amazon.com>