### PR TITLE
Updated prefabs to follow new pattern that colliders require a rigid body

### DIFF
--- a/Assets/Props/oak_tree/oak_tree.prefab
+++ b/Assets/Props/oak_tree/oak_tree.prefab
@@ -90,6 +90,10 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 18370362298751193885
                 },
+                "Component_[5545594614568177491]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5545594614568177491
+                },
                 "Component_[6495291924243783671]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 6495291924243783671
@@ -252,6 +256,10 @@
                             "SortIndex": 2
                         }
                     ]
+                },
+                "Component_[9970428173110314776]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9970428173110314776
                 }
             }
         }

--- a/Levels/CharacterSample/CharacterSample.prefab
+++ b/Levels/CharacterSample/CharacterSample.prefab
@@ -220,6 +220,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 7090012899106946164
                 },
+                "Component_[9183157961446999764]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9183157961446999764
+                },
                 "Component_[9410832619875640998]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 9410832619875640998
@@ -3651,7 +3655,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[17603529919546135644]/Transform Data/Rotate/0",
-                    "value": -25.374065399169922
+                    "value": -25.37406539916992
                 },
                 {
                     "op": "replace",

--- a/Levels/Neighborhood/Neighborhood.prefab
+++ b/Levels/Neighborhood/Neighborhood.prefab
@@ -235,8 +235,7 @@
                                 0.6078431606292725
                             ],
                             "FogStartDistance": 0.0,
-                            "FogEndDistance": 2000.0,
-                            "IsEnabled": true
+                            "FogEndDistance": 2000.0
                         }
                     }
                 },
@@ -578,6 +577,10 @@
             "Id": "Entity_[402703138839801]",
             "Name": "Wall",
             "Components": {
+                "Component_[11731398738794320804]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11731398738794320804
+                },
                 "Component_[12552237852692690151]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 12552237852692690151
@@ -651,6 +654,10 @@
             "Id": "Entity_[402720318708985]",
             "Name": "Wall",
             "Components": {
+                "Component_[11654883349265409901]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11654883349265409901
+                },
                 "Component_[12552237852692690151]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 12552237852692690151
@@ -765,6 +772,10 @@
                         ]
                     }
                 },
+                "Component_[4597476229061883022]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4597476229061883022
+                },
                 "Component_[5413950866394649821]": {
                     "$type": "EditorLockComponent",
                     "Id": 5413950866394649821
@@ -802,6 +813,10 @@
             "Id": "Entity_[402746088512761]",
             "Name": "Wall",
             "Components": {
+                "Component_[12530857459441702109]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12530857459441702109
+                },
                 "Component_[12552237852692690151]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 12552237852692690151

--- a/Prefabs/Fence.prefab
+++ b/Prefabs/Fence.prefab
@@ -176,6 +176,10 @@
                 "Component_[8150173855034130240]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 8150173855034130240
+                },
+                "Component_[8656125004053664482]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8656125004053664482
                 }
             }
         }

--- a/Prefabs/FireHydrant.prefab
+++ b/Prefabs/FireHydrant.prefab
@@ -77,6 +77,10 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 11370502590986216815
                 },
+                "Component_[12360471041399542757]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12360471041399542757
+                },
                 "Component_[1437904913575547325]": {
                     "$type": "EditorLockComponent",
                     "Id": 1437904913575547325

--- a/Prefabs/HouseFour.prefab
+++ b/Prefabs/HouseFour.prefab
@@ -360,6 +360,10 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5374064654898669998
                 },
+                "Component_[6844516215859402941]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6844516215859402941
+                },
                 "Component_[7586760209761160177]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 7586760209761160177
@@ -588,6 +592,10 @@
                             }
                         }
                     }
+                },
+                "Component_[2337858081698443256]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2337858081698443256
                 },
                 "Component_[522534646951967812]": {
                     "$type": "EditorLockComponent",

--- a/Prefabs/HouseOne.prefab
+++ b/Prefabs/HouseOne.prefab
@@ -72,6 +72,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 4089949034111969353
                 },
+                "Component_[4330517456005722858]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4330517456005722858
+                },
                 "Component_[440058443217281667]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 440058443217281667
@@ -446,6 +450,10 @@
                 "Component_[17533464519890533603]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 17533464519890533603
+                },
+                "Component_[17616891988493510389]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17616891988493510389
                 },
                 "Component_[1840150263333645744]": {
                     "$type": "EditorEntitySortComponent",

--- a/Prefabs/HouseThree.prefab
+++ b/Prefabs/HouseThree.prefab
@@ -278,6 +278,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 5253808659116847058
                 },
+                "Component_[6901803588474416989]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6901803588474416989
+                },
                 "Component_[7015330279787534294]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 7015330279787534294
@@ -474,6 +478,10 @@
                 "Component_[5810197542871238612]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 5810197542871238612
+                },
+                "Component_[7338685398404292051]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7338685398404292051
                 },
                 "Component_[8190325209977572815]": {
                     "$type": "EditorOnlyEntityComponent",

--- a/Prefabs/HouseTwo.prefab
+++ b/Prefabs/HouseTwo.prefab
@@ -205,6 +205,10 @@
                         ]
                     }
                 },
+                "Component_[7541655689040331415]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7541655689040331415
+                },
                 "Component_[8445136296963424565]": {
                     "$type": "EditorMaterialComponent",
                     "Id": 8445136296963424565,
@@ -627,6 +631,10 @@
                             ]
                         }
                     }
+                },
+                "Component_[5005662653106702213]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5005662653106702213
                 },
                 "Component_[6571501850434631224]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/Prefabs/LawnMowerZone.prefab
+++ b/Prefabs/LawnMowerZone.prefab
@@ -87,6 +87,10 @@
                         }
                     }
                 },
+                "Component_[14573040223821145637]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14573040223821145637
+                },
                 "Component_[1606135258485992951]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 1606135258485992951

--- a/Prefabs/MailBox.prefab
+++ b/Prefabs/MailBox.prefab
@@ -186,6 +186,10 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 16155004073691733077
                 },
+                "Component_[17083015125599233982]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17083015125599233982
+                },
                 "Component_[17411422417334134722]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 17411422417334134722

--- a/Prefabs/ManHoleCover.prefab
+++ b/Prefabs/ManHoleCover.prefab
@@ -54,6 +54,10 @@
             "Id": "Entity_[17092586091657]",
             "Name": "ManHoleCover",
             "Components": {
+                "Component_[11109668287515108186]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11109668287515108186
+                },
                 "Component_[11535314335853008448]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 11535314335853008448

--- a/Prefabs/MowerBlue.prefab
+++ b/Prefabs/MowerBlue.prefab
@@ -153,6 +153,10 @@
                         }
                     }
                 },
+                "Component_[2454840315227663864]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2454840315227663864
+                },
                 "Component_[4284763451099931820]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 4284763451099931820,

--- a/Prefabs/MowerRed.prefab
+++ b/Prefabs/MowerRed.prefab
@@ -176,6 +176,10 @@
                         }
                     }
                 },
+                "Component_[4168226176891248108]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4168226176891248108
+                },
                 "Component_[4284763451099931820]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 4284763451099931820,

--- a/Prefabs/MowerYellow.prefab
+++ b/Prefabs/MowerYellow.prefab
@@ -62,6 +62,10 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 10882499800015952800
                 },
+                "Component_[11273410122192242682]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11273410122192242682
+                },
                 "Component_[12449723034020257013]": {
                     "$type": "AZ::Render::EditorMeshComponent",
                     "Id": 12449723034020257013,

--- a/Prefabs/Neighborhood_Street.prefab
+++ b/Prefabs/Neighborhood_Street.prefab
@@ -116,6 +116,10 @@
                         ]
                     }
                 },
+                "Component_[5342711307765022692]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5342711307765022692
+                },
                 "Component_[5425030871546260761]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5425030871546260761
@@ -299,6 +303,10 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5425030871546260761
                 },
+                "Component_[6930000572299942244]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6930000572299942244
+                },
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
@@ -373,6 +381,10 @@
                 "Component_[5425030871546260761]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5425030871546260761
+                },
+                "Component_[646601473604075087]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 646601473604075087
                 },
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
@@ -452,6 +464,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[9568300305292441252]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9568300305292441252
                 }
             }
         },
@@ -652,6 +668,10 @@
                 "Component_[11175533720307839166]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 11175533720307839166
+                },
+                "Component_[12613969957424813266]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12613969957424813266
                 },
                 "Component_[14556184623190542456]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -941,6 +961,10 @@
                     "Id": 2951404122384185410,
                     "Parent Entity": "Entity_[1761389267650]"
                 },
+                "Component_[3800516168544047052]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3800516168544047052
+                },
                 "Component_[7545753375962325447]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 7545753375962325447
@@ -1002,6 +1026,10 @@
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
                     "Id": 13865395273471462692
+                },
+                "Component_[14384710027963322604]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14384710027963322604
                 },
                 "Component_[15112293839189480095]": {
                     "$type": "EditorVisibilityComponent",
@@ -1341,6 +1369,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 13865395273471462692
                 },
+                "Component_[14040517885641381226]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14040517885641381226
+                },
                 "Component_[15112293839189480095]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15112293839189480095
@@ -1447,6 +1479,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[9559084541107928631]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9559084541107928631
                 }
             }
         },
@@ -1502,6 +1538,10 @@
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
+                },
+                "Component_[3576689897607240840]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3576689897607240840
                 },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -1577,6 +1617,10 @@
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
+                },
+                "Component_[17158596007554786592]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17158596007554786592
                 },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -1672,6 +1716,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[9557689594914479583]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9557689594914479583
                 }
             }
         },
@@ -1723,6 +1771,10 @@
                 "Component_[16392630281430194629]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 16392630281430194629
+                },
+                "Component_[16803593610717049480]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 16803593610717049480
                 },
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
@@ -1790,6 +1842,10 @@
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
                     "Id": 13865395273471462692
+                },
+                "Component_[14158007792103958532]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14158007792103958532
                 },
                 "Component_[15112293839189480095]": {
                     "$type": "EditorVisibilityComponent",
@@ -1874,6 +1930,10 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 16392630281430194629
                 },
+                "Component_[16458105834784156454]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 16458105834784156454
+                },
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
@@ -1952,6 +2012,10 @@
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
+                },
+                "Component_[2744163725435853641]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2744163725435853641
                 },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -2047,6 +2111,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[8839911778548044994]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8839911778548044994
                 }
             }
         },
@@ -2086,6 +2154,10 @@
                             "Radius": 0.20000000298023224
                         }
                     }
+                },
+                "Component_[13354064075713166495]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13354064075713166495
                 },
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
@@ -2178,6 +2250,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
                 },
+                "Component_[3753620117395867378]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3753620117395867378
+                },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 4237093589185079037,
@@ -2269,6 +2345,10 @@
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5425030871546260761
                 },
+                "Component_[6899648409187432679]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6899648409187432679
+                },
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
@@ -2282,6 +2362,10 @@
                 "Component_[10273587952372416394]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 10273587952372416394
+                },
+                "Component_[10655608667094648867]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10655608667094648867
                 },
                 "Component_[11532464851403649221]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -2415,6 +2499,10 @@
                         ]
                     }
                 },
+                "Component_[4950448238967895307]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4950448238967895307
+                },
                 "Component_[5425030871546260761]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5425030871546260761
@@ -2497,6 +2585,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[8583737825101579132]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8583737825101579132
                 }
             }
         },
@@ -2552,6 +2644,10 @@
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
+                },
+                "Component_[4161567345490323031]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4161567345490323031
                 },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -2615,6 +2711,10 @@
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
                     "Id": 13865395273471462692
+                },
+                "Component_[14087331007096397231]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14087331007096397231
                 },
                 "Component_[15112293839189480095]": {
                     "$type": "EditorVisibilityComponent",
@@ -2703,6 +2803,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
                 },
+                "Component_[2204498082812947244]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2204498082812947244
+                },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 4237093589185079037,
@@ -2778,6 +2882,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
                 },
+                "Component_[2316855936637809944]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2316855936637809944
+                },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 4237093589185079037,
@@ -2840,6 +2948,10 @@
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
                     "Id": 13865395273471462692
+                },
+                "Component_[14693120261594707531]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14693120261594707531
                 },
                 "Component_[15112293839189480095]": {
                     "$type": "EditorVisibilityComponent",
@@ -2928,6 +3040,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
                 },
+                "Component_[183616121388484703]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 183616121388484703
+                },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 4237093589185079037,
@@ -3003,6 +3119,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
                 },
+                "Component_[2933989115179506742]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2933989115179506742
+                },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 4237093589185079037,
@@ -3077,6 +3197,10 @@
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
+                },
+                "Component_[17828179187205767650]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17828179187205767650
                 },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -3172,6 +3296,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[8326955055003655611]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8326955055003655611
                 }
             }
         },
@@ -3227,6 +3355,10 @@
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
+                },
+                "Component_[18395618461044427598]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 18395618461044427598
                 },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -3286,6 +3418,10 @@
                             "Radius": 0.11999999731779099
                         }
                     }
+                },
+                "Component_[12957779051691122268]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12957779051691122268
                 },
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
@@ -3378,6 +3514,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
                 },
+                "Component_[17930911648722965378]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17930911648722965378
+                },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 4237093589185079037,
@@ -3440,6 +3580,10 @@
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
                     "Id": 13865395273471462692
+                },
+                "Component_[14038391578604957324]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14038391578604957324
                 },
                 "Component_[15112293839189480095]": {
                     "$type": "EditorVisibilityComponent",
@@ -3547,6 +3691,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[8726483833803448386]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8726483833803448386
                 }
             }
         },
@@ -3622,6 +3770,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[8637426244361704905]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8637426244361704905
                 }
             }
         },
@@ -3669,6 +3821,10 @@
                 "Component_[15112293839189480095]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15112293839189480095
+                },
+                "Component_[16279493780120394587]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 16279493780120394587
                 },
                 "Component_[16392630281430194629]": {
                     "$type": "EditorDisabledCompositionComponent",
@@ -3736,6 +3892,10 @@
                             "Radius": 0.20000000298023224
                         }
                     }
+                },
+                "Component_[1350023025219207275]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1350023025219207275
                 },
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
@@ -3822,6 +3982,10 @@
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
                     "Id": 13865395273471462692
+                },
+                "Component_[1430386830466584110]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1430386830466584110
                 },
                 "Component_[15112293839189480095]": {
                     "$type": "EditorVisibilityComponent",
@@ -3936,6 +4100,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[826515418303919094]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 826515418303919094
                 }
             }
         },
@@ -3998,6 +4166,10 @@
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
+                },
+                "Component_[1839542734866774345]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1839542734866774345
                 },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -4080,6 +4252,10 @@
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
+                },
+                "Component_[3057166958214254835]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 3057166958214254835
                 },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -4175,6 +4351,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[886574255654812303]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 886574255654812303
                 }
             }
         },
@@ -4185,6 +4365,10 @@
                 "Component_[10273587952372416394]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 10273587952372416394
+                },
+                "Component_[10331073755247109625]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10331073755247109625
                 },
                 "Component_[11532464851403649221]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -4318,6 +4502,10 @@
                         ]
                     }
                 },
+                "Component_[499020307800893028]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 499020307800893028
+                },
                 "Component_[5425030871546260761]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5425030871546260761
@@ -4380,6 +4568,10 @@
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
+                },
+                "Component_[1846179456707386047]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1846179456707386047
                 },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -4456,6 +4648,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
                 },
+                "Component_[17528362866351195459]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17528362866351195459
+                },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 4237093589185079037,
@@ -4531,6 +4727,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
                 },
+                "Component_[17540399028749504957]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17540399028749504957
+                },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 4237093589185079037,
@@ -4589,6 +4789,10 @@
                             "Radius": 0.07500000298023224
                         }
                     }
+                },
+                "Component_[13107581161295331204]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13107581161295331204
                 },
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
@@ -4668,6 +4872,10 @@
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
                     "Id": 13865395273471462692
+                },
+                "Component_[14067045747897520894]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14067045747897520894
                 },
                 "Component_[15112293839189480095]": {
                     "$type": "EditorVisibilityComponent",
@@ -4755,6 +4963,10 @@
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
+                },
+                "Component_[4198343669829572690]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4198343669829572690
                 },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -4850,6 +5062,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[8719445221054761247]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8719445221054761247
                 }
             }
         },
@@ -4893,6 +5109,10 @@
                 "Component_[13865395273471462692]": {
                     "$type": "EditorLockComponent",
                     "Id": 13865395273471462692
+                },
+                "Component_[14046518523183756243]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14046518523183756243
                 },
                 "Component_[15112293839189480095]": {
                     "$type": "EditorVisibilityComponent",
@@ -4993,6 +5213,10 @@
                         ]
                     }
                 },
+                "Component_[5081760309165341788]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5081760309165341788
+                },
                 "Component_[5425030871546260761]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 5425030871546260761
@@ -5010,6 +5234,10 @@
                 "Component_[10273587952372416394]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 10273587952372416394
+                },
+                "Component_[11115523350419298364]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11115523350419298364
                 },
                 "Component_[11532464851403649221]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -5119,6 +5347,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 13865395273471462692
                 },
+                "Component_[14390057756033421864]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 14390057756033421864
+                },
                 "Component_[15112293839189480095]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15112293839189480095
@@ -5225,6 +5457,10 @@
                 "Component_[7093177262667468283]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 7093177262667468283
+                },
+                "Component_[9882598341732590406]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9882598341732590406
                 }
             }
         },
@@ -5235,6 +5471,10 @@
                 "Component_[10273587952372416394]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 10273587952372416394
+                },
+                "Component_[11022322446622461164]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11022322446622461164
                 },
                 "Component_[11532464851403649221]": {
                     "$type": "EditorOnlyEntityComponent",
@@ -5355,6 +5595,10 @@
                 "Component_[16945603370701392467]": {
                     "$type": "EditorEntityIconComponent",
                     "Id": 16945603370701392467
+                },
+                "Component_[18089594648782325281]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 18089594648782325281
                 },
                 "Component_[4237093589185079037]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",

--- a/Prefabs/NewspaperTarget.prefab
+++ b/Prefabs/NewspaperTarget.prefab
@@ -86,6 +86,10 @@
                         "Instance_[46372565521295]/ContainerEntity"
                     ]
                 },
+                "Component_[15269032430946969616]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 15269032430946969616
+                },
                 "Component_[15856588326937305232]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 15856588326937305232

--- a/Prefabs/NewspaperTargetMailbox_250.prefab
+++ b/Prefabs/NewspaperTargetMailbox_250.prefab
@@ -88,6 +88,10 @@
                         }
                     }
                 },
+                "Component_[13230569198006657759]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13230569198006657759
+                },
                 "Component_[15015757342638693767]": {
                     "$type": "EditorLockComponent",
                     "Id": 15015757342638693767

--- a/Prefabs/NewspaperTargetPorch_100.prefab
+++ b/Prefabs/NewspaperTargetPorch_100.prefab
@@ -141,6 +141,10 @@
                         }
                     }
                 },
+                "Component_[9274801788652608106]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9274801788652608106
+                },
                 "Component_[9771282421624609467]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 9771282421624609467,

--- a/Prefabs/NewspaperTruck.prefab
+++ b/Prefabs/NewspaperTruck.prefab
@@ -437,6 +437,10 @@
                         ]
                     }
                 },
+                "Component_[8870485923821766980]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8870485923821766980
+                },
                 "Component_[9815773085486113979]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 9815773085486113979
@@ -577,6 +581,10 @@
                     "$type": "EditorEntityIconComponent",
                     "Id": 3891664416649747444
                 },
+                "Component_[7202892845969300396]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7202892845969300396
+                },
                 "Component_[7372186200357251224]": {
                     "$type": "EditorLockComponent",
                     "Id": 7372186200357251224
@@ -698,6 +706,10 @@
                 "Component_[13433142402633255472]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 13433142402633255472
+                },
+                "Component_[13550130004525770094]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 13550130004525770094
                 },
                 "Component_[14098718602576607786]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
@@ -956,6 +968,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 7372186200357251224
                 },
+                "Component_[7762825402017612318]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7762825402017612318
+                },
                 "Component_[7984874516937459267]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 7984874516937459267
@@ -1054,6 +1070,10 @@
             "Id": "Entity_[12632247753224]",
             "Name": "Paper Stack",
             "Components": {
+                "Component_[11605912514343310129]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11605912514343310129
+                },
                 "Component_[12301967286089635206]": {
                     "$type": "EditorEntitySortComponent",
                     "Id": 12301967286089635206,
@@ -1428,6 +1448,10 @@
                     "$type": "EditorLockComponent",
                     "Id": 7372186200357251224
                 },
+                "Component_[7975649740561395201]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 7975649740561395201
+                },
                 "Component_[7984874516937459267]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 7984874516937459267
@@ -1771,6 +1795,10 @@
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 7984874516937459267
                 },
+                "Component_[8348758570132970053]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8348758570132970053
+                },
                 "Component_[9136279365155419968]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 9136279365155419968
@@ -1781,6 +1809,10 @@
             "Id": "Entity_[12658017557000]",
             "Name": "newsman",
             "Components": {
+                "Component_[12929987276517465871]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 12929987276517465871
+                },
                 "Component_[13518123529242602499]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13518123529242602499

--- a/Prefabs/Tires.prefab
+++ b/Prefabs/Tires.prefab
@@ -164,6 +164,10 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 5070413789210127474
                 },
+                "Component_[5171927639457227895]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 5171927639457227895
+                },
                 "Component_[5998563097834704127]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 5998563097834704127

--- a/Prefabs/Tombstone.prefab
+++ b/Prefabs/Tombstone.prefab
@@ -144,6 +144,10 @@
                         }
                     }
                 },
+                "Component_[6596056067012513542]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 6596056067012513542
+                },
                 "Component_[6834075519874446239]": {
                     "$type": "EditorInspectorComponent",
                     "Id": 6834075519874446239,

--- a/Prefabs/TrashCan.prefab
+++ b/Prefabs/TrashCan.prefab
@@ -54,6 +54,10 @@
             "Id": "Entity_[13583597810825]",
             "Name": "TrashCan",
             "Components": {
+                "Component_[10537206701491798109]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 10537206701491798109
+                },
                 "Component_[10789493722774215242]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 10789493722774215242


### PR DESCRIPTION
Signed-off-by: moraaar <moraaar@amazon.com>

Update prefabs with `ed_physxUpdatePrefabsWithColliderComponents` for PhysX.

More information about this update here: https://github.com/o3de/o3de/pull/14418