### PR TITLE
Updated colliders in prefabs by running 'ed_physxUpdatePrefabsWithColliderComponents' command

### DIFF
--- a/Prefabs/HouseFour.prefab
+++ b/Prefabs/HouseFour.prefab
@@ -236,7 +236,7 @@
                     "Id": 13896639662179397093
                 },
                 "Component_[1666971396640748166]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 1666971396640748166,
                     "ColliderConfiguration": {
                         "CollisionLayer": {
@@ -606,7 +606,7 @@
                     "Id": 7009583241746681559
                 },
                 "Component_[7902755800221254700]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7902755800221254700,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Prefabs/HouseOne.prefab
+++ b/Prefabs/HouseOne.prefab
@@ -107,7 +107,7 @@
                     ]
                 },
                 "Component_[7276057032838070705]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7276057032838070705,
                     "ColliderConfiguration": {
                         "CollisionLayer": {
@@ -375,7 +375,7 @@
                     "Id": 11796920948167762112
                 },
                 "Component_[13217889949763174505]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 13217889949763174505,
                     "ColliderConfiguration": {
                         "MaterialSlots": {

--- a/Prefabs/HouseThree.prefab
+++ b/Prefabs/HouseThree.prefab
@@ -287,7 +287,7 @@
                     "Id": 7015330279787534294
                 },
                 "Component_[8537454777747208414]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 8537454777747208414,
                     "ColliderConfiguration": {
                         "CollisionLayer": {
@@ -388,7 +388,7 @@
                     "Id": 2366239717659653207
                 },
                 "Component_[2925782240960850520]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 2925782240960850520,
                     "ColliderConfiguration": {
                         "CollisionLayer": {

--- a/Prefabs/HouseTwo.prefab
+++ b/Prefabs/HouseTwo.prefab
@@ -117,7 +117,7 @@
                     "Id": 3627023003841364183
                 },
                 "Component_[4053479541161709826]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 4053479541161709826,
                     "ColliderConfiguration": {
                         "CollisionLayer": {
@@ -399,7 +399,7 @@
                     "Id": 16162208256784420554
                 },
                 "Component_[16258631589039510913]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 16258631589039510913,
                     "ColliderConfiguration": {
                         "CollisionLayer": {

--- a/Prefabs/Neighborhood_Street.prefab
+++ b/Prefabs/Neighborhood_Street.prefab
@@ -732,7 +732,7 @@
                     "Id": 4362258541834846362
                 },
                 "Component_[6460084305053662076]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 6460084305053662076,
                     "ColliderConfiguration": {
                         "CollisionLayer": {
@@ -882,7 +882,7 @@
                     "Id": 12509959461453420030
                 },
                 "Component_[12892409599045525463]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 12892409599045525463,
                     "ColliderConfiguration": {
                         "CollisionLayer": {

--- a/Prefabs/Van_Blue.prefab
+++ b/Prefabs/Van_Blue.prefab
@@ -273,7 +273,7 @@
                     }
                 },
                 "Component_[7469649431801341611]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7469649431801341611,
                     "ColliderConfiguration": {
                         "Position": [
@@ -382,7 +382,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[16955837687875173044]/Transform Data/Translate/0",
-                    "value": -1.0756397247314453
+                    "value": -1.075639724731445
                 },
                 {
                     "op": "replace",
@@ -417,7 +417,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[16955837687875173044]/Transform Data/Translate/0",
-                    "value": 0.9421262741088867
+                    "value": 0.9421262741088868
                 },
                 {
                     "op": "replace",

--- a/Prefabs/Van_Red.prefab
+++ b/Prefabs/Van_Red.prefab
@@ -273,7 +273,7 @@
                     }
                 },
                 "Component_[7469649431801341611]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7469649431801341611,
                     "ColliderConfiguration": {
                         "Position": [

--- a/Prefabs/Van_Yellow.prefab
+++ b/Prefabs/Van_Yellow.prefab
@@ -273,7 +273,7 @@
                     }
                 },
                 "Component_[7469649431801341611]": {
-                    "$type": "EditorColliderComponent",
+                    "$type": "EditorMeshColliderComponent",
                     "Id": 7469649431801341611,
                     "ColliderConfiguration": {
                         "Position": [


### PR DESCRIPTION
**Note**
This is part of the work to separate PhysX Collider into 2 components: https://github.com/o3de/o3de/pull/14725. 
This is currently as draft to avoid submitting it too early.

**Reviewers**
Please review and approve this draft and once the main change is submitted into o3de I will merge this as well.

**Testing**
All converted prefabs were processed successfully by the Asset Processor. 
Played the game. Manually checked a converted prefab in the level had the correct PhysX Mesh Collider.

Signed-off-by: moraaar <moraaar@amazon.com>