### PR TITLE
Adjust seedlist file to allow for multiple platforms

### DIFF
--- a/AssetBundling/SeedLists/GameSeedList.seed
+++ b/AssetBundling/SeedLists/GameSeedList.seed
@@ -5,7 +5,7 @@
 				<Class name="AZ::Uuid" field="guid" value="{1D536812-64D4-5EF7-8A76-C45C37BBFC46}" type="{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"/>
 				<Class name="unsigned int" field="subId" value="3523287157" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			</Class>
-			<Class name="unsigned int" field="platformFlags" value="1" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
+			<Class name="unsigned int" field="platformFlags" value="255" type="{43DA906B-7DEF-4CA8-9790-854106D3F983}"/>
 			<Class name="AZStd::string" field="pathHint" value="levels/neighborhood/neighborhood.spawnable" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 		</Class>
 	</Class>


### PR DESCRIPTION
In my recent test for getting Newspaper Delivery game to export as an APK with pak files bundled, I had to adjust the game level's seedlist platform flags so that android would be supported.

I opted to use the flag `255`, as I anticipate needing to support iOS as well.