### PR TITLE
fix: autoexec.cfg loads the actual default level, not a missing "start" placeholder

### DIFF
--- a/autoexec.cfg
+++ b/autoexec.cfg
@@ -1,6 +1,6 @@
 ; edit this file to make it load whatever level you want on startup automatically
 ; You can also add additional commands in here that you want it to exec on startup.
-loadlevel start
+loadlevel Neighborhood
 
 ; uncomment the following line in any game packages that have all the
 ; assets precompiled, so that it doesn't try to launch the Asset Processor in


### PR DESCRIPTION
## Problem

`autoexec.cfg` shipped with `loadlevel start`, but no level named "start" exists in the project. On launch, the level system logs `Requested level not found: 'start'` and the launcher parks in a non-rendering state -- a new user sees a black window with no indication of what went wrong.

The placeholder `start` was inherited from the engine's `ScriptOnlyProject` template; this project never customized it.

## Fix

Change the autoexec to load `Neighborhood`, which matches the default already set in `Registry/game.setreg`.

An alternative would be to delete the `loadlevel` line entirely and let `Registry/game.setreg` drive the default; I went with the minimum-edit form so the autoexec.cfg stays a working starting point that downstream forks / template-derived projects can copy from. Happy to switch to the delete form if maintainers prefer.

## Verification

Built and ran on Fedora 44 / NVIDIA RTX 2080 Ti / Vulkan RHI.

Verified visually:
- Title screen renders cleanly
- Score / lives / home-time HUD active
- Character input + movement works

From Game.log:
- `Game Level Load Time: [...] Level Levels/Neighborhood/Neighborhood.spawnable loaded` present
- No `Requested level not found` warnings

## Note for maintainers

The same `loadlevel start` placeholder ships in O3DE's `ScriptOnlyProject` template at `Templates/ScriptOnlyProject/Template/autoexec.cfg`. Worth a separate engine-side fix to comment it out or change it to `; loadlevel YourLevelName` so future template-generated projects don't inherit the same broken default. Happy to file a separate engine-side PR if useful.