### PR TITLE
docs: mark 26.05.0+ as a supported O3DE version line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<u>Supported o3de versions</u> : **24.09.2**
+<u>Supported o3de versions</u> : **24.09.2, 26.05.0+**
 
 # Newspaper Delivery Game
 


### PR DESCRIPTION
## Motivation

The README's `Supported o3de versions` header was last set to `24.09.2` (released ~Sep 2024). The project builds + runs cleanly on the 26.05.0 line; this PR adds it to the header so the README doesn't suggest the project rotted between 24.09 and 26.05.

## Verification

Built + ran end-to-end on Fedora 44 / NVIDIA RTX 2080 Ti / Vulkan RHI against an installed o3de 26.05.0:

- `o3de.sh register -p` succeeds
- `cmake -GNinja` configure clean
- `AssetProcessorBatch --platforms=linux` over the full project bakes 3672 jobs with zero failures
- `O3DE.GameLauncher` boots, loads `Levels/Neighborhood/Neighborhood.spawnable`, HUD active (score / lives / home-time / newspaper count), character control works

(With the autoexec fix from #20 applied; that PR addresses a separate issue where the default level pointer was a placeholder.)

## Scope

One-line change to the version header. Larger README improvements (Linux/Fedora install path, CLI workflow, troubleshooting) could follow once #20 lands -- happy to file separately.